### PR TITLE
Fix MFA placeholder

### DIFF
--- a/templates/auth/mfa_verify.html
+++ b/templates/auth/mfa_verify.html
@@ -24,8 +24,8 @@
                     
                     <div class="mb-3">
                         {{ form.code.label(class="form-label") }}
-                        {{ form.code(class="form-control form-control-lg text-center" + (" is-invalid" if form.code.errors else ""), 
-                                     placeholder="Entrez le code à 6 chiffres", maxlength="12", autocomplete="off") }}
+                            {{ form.code(class="form-control form-control-lg text-center" + (" is-invalid" if form.code.errors else ""),
+                                     placeholder="Entrez le code à 12 caractères", maxlength="12", autocomplete="off") }}
                         {% if form.code.errors %}
                             <div class="invalid-feedback">
                                 {% for error in form.code.errors %}


### PR DESCRIPTION
## Summary
- update MFA placeholder to indicate the 12-character code

## Testing
- `SECRET_KEY=test PYTHONPATH=$PWD pytest -q` *(fails: TemplateNotFound: auth/register.html)*

------
https://chatgpt.com/codex/tasks/task_e_68884ada08e08329a415c9290d6e1d3f