### PR TITLE
Add bulk sample data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Après l'initialisation des données d'exemple :
 
 | Rôle | Email | Mot de passe |
 |------|--------|-------------|
-| **Administrateur** | admin@school.fr | admin123 |
-| **Professeur** | prof.martin@school.fr | teacher123 |
-| **Étudiant** | etudiant.dupont@school.fr | student123 |
-| **Parent** | parent.dupont@email.fr | parent123 |
+| **Administrateur** | ulbis047@gmail.com | admin123 |
+| **Professeur** | gbtexfares@gmail.com | teacher123 |
+| **Étudiant** | dossoufares@gmail.com | student123 |
+| **Parent** | mlalarochelle17x@gmail.com | parent123 |
 
 ## 🏗️ Architecture
 

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -1,173 +1,262 @@
 from models import db, Role, User, Student, Parent, Teacher, Administrator, Course, Grade, Absence, Schedule, ParentStudent
-from datetime import date, time, datetime
-import secrets
+from datetime import date, time, datetime, timedelta
+import random
+
 
 def create_sample_data():
-    """Crée des données d'exemple pour tester l'application"""
-    
-    # Créer les rôles s'ils n'existent pas
-    roles_data = [
-        ('student', 'Étudiant'),
-        ('parent', 'Parent'),
-        ('teacher', 'Professeur'),
-        ('admin', 'Administrateur')
-    ]
-    
-    for role_name, role_desc in roles_data:
-        if not Role.query.filter_by(name=role_name).first():
-            role = Role(name=role_name, description=role_desc)
-            db.session.add(role)
-    
+    """Populate the database with a large sample dataset."""
+
+    # Roles
+    roles = {
+        'student': 'Étudiant',
+        'parent': 'Parent',
+        'teacher': 'Professeur',
+        'admin': 'Administrateur'
+    }
+    for rname, desc in roles.items():
+        if not Role.query.filter_by(name=rname).first():
+            db.session.add(Role(name=rname, description=desc))
     db.session.commit()
-    
-    # Récupérer les rôles
+
     student_role = Role.query.filter_by(name='student').first()
     parent_role = Role.query.filter_by(name='parent').first()
     teacher_role = Role.query.filter_by(name='teacher').first()
     admin_role = Role.query.filter_by(name='admin').first()
-    
-    # Créer un administrateur par défaut
-    if not User.query.filter_by(email='admin@school.fr').first():
-        admin_user = User(
-            email='admin@school.fr',
-            first_name='Admin',
-            last_name='Système',
-            role_id=admin_role.id,
-            is_active=True
-        )
-        admin_user.set_password('admin123')
-        db.session.add(admin_user)
+
+    # Predefined accounts for testing
+    if not User.query.filter_by(email='ulbis047@gmail.com').first():
+        user = User(email='ulbis047@gmail.com',
+                    first_name='Test',
+                    last_name='Admin',
+                    role_id=admin_role.id,
+                    is_active=True)
+        user.set_password('admin123')
+        db.session.add(user)
         db.session.commit()
-        
-        admin_profile = Administrator(
-            user_id=admin_user.id,
-            employee_number='ADM001',
-            position='Administrateur Système'
-        )
+        admin_profile = Administrator(user_id=user.id,
+                                      employee_number='ADM900',
+                                      position='Administrateur')
         db.session.add(admin_profile)
-    
-    # Créer des professeurs
-    teachers_data = [
-        ('prof.martin@school.fr', 'Jean', 'Martin', 'PROF001', 'Mathématiques'),
-        ('prof.durand@school.fr', 'Marie', 'Durand', 'PROF002', 'Français'),
-        ('prof.bernard@school.fr', 'Pierre', 'Bernard', 'PROF003', 'Histoire')
-    ]
-    
-    for email, first_name, last_name, emp_num, dept in teachers_data:
+        db.session.commit()
+    # Administrators
+    for i in range(1, 4):
+        email = f"admin{i}@school.fr"
         if not User.query.filter_by(email=email).first():
-            teacher_user = User(
-                email=email,
-                first_name=first_name,
-                last_name=last_name,
-                role_id=teacher_role.id,
-                is_active=True
-            )
-            teacher_user.set_password('teacher123')
-            db.session.add(teacher_user)
+            user = User(email=email,
+                        first_name=f"Admin{i}",
+                        last_name="Ecole",
+                        role_id=admin_role.id,
+                        is_active=True)
+            user.set_password('admin123')
+            db.session.add(user)
             db.session.commit()
-            
-            teacher_profile = Teacher(
-                user_id=teacher_user.id,
-                employee_number=emp_num,
-                department=dept,
-                hire_date=date.today()
-            )
-            db.session.add(teacher_profile)
-    
-    # Créer des étudiants
-    students_data = [
-        ('gbtexfares@gmail.com', 'Lucas', 'Dupont', 'STU001', '6A'),
-        ('etudiant.moreau@school.fr', 'Emma', 'Moreau', 'STU002', '6A'),
-        ('etudiant.petit@school.fr', 'Nathan', 'Petit', 'STU003', '6B')
-    ]
-    
-    for email, first_name, last_name, stu_num, class_name in students_data:
-        if not User.query.filter_by(email=email).first():
-            student_user = User(
-                email=email,
-                first_name=first_name,
-                last_name=last_name,
-                role_id=student_role.id,
-                is_active=True
-            )
-            student_user.set_password('student123')
-            db.session.add(student_user)
-            db.session.commit()
-            
-            student_profile = Student(
-                user_id=student_user.id,
-                student_number=stu_num,
-                class_name=class_name,
-                enrollment_date=date.today()
-            )
-            db.session.add(student_profile)
-    
-    # Créer des parents
-    parents_data = [
-        ('parent.dupont@email.fr', 'François', 'Dupont'),
-        ('parent.moreau@email.fr', 'Sophie', 'Moreau')
-    ]
-    
-    for email, first_name, last_name in parents_data:
-        if not User.query.filter_by(email=email).first():
-            parent_user = User(
-                email=email,
-                first_name=first_name,
-                last_name=last_name,
-                role_id=parent_role.id,
-                is_active=True
-            )
-            parent_user.set_password('parent123')
-            db.session.add(parent_user)
-            db.session.commit()
-            
-            parent_profile = Parent(user_id=parent_user.id)
-            db.session.add(parent_profile)
-    
+            admin = Administrator(user_id=user.id,
+                                  employee_number=f"ADM{i:03d}",
+                                  position="Administrateur")
+            db.session.add(admin)
     db.session.commit()
-    
-    # Lier parents et enfants
-    parent_dupont = Parent.query.join(User).filter(User.email == 'parent.dupont@email.fr').first()
-    student_dupont = Student.query.join(User).filter(User.email == 'etudiant.dupont@school.fr').first()
-    
-    if parent_dupont and student_dupont:
-        if not ParentStudent.query.filter_by(parent_id=parent_dupont.id, student_id=student_dupont.id).first():
-            parent_student = ParentStudent(
-                parent_id=parent_dupont.id,
-                student_id=student_dupont.id,
-                relationship_type='père'
-            )
-            db.session.add(parent_student)
-    
-    # Créer des matières
-    courses_data = [
-        ('Mathématiques 6ème', 'MATH6', 'Cours de mathématiques niveau 6ème', 4),
-        ('Français 6ème', 'FR6', 'Cours de français niveau 6ème', 5),
-        ('Histoire 6ème', 'HIST6', 'Cours d\'histoire niveau 6ème', 3)
+
+    # Teachers
+    teachers = []
+    for i in range(1, 31):
+        email = f"teacher{i}@school.fr"
+        if not User.query.filter_by(email=email).first():
+            user = User(email=email,
+                        first_name=f"Prof{i}",
+                        last_name="Demo",
+                        role_id=teacher_role.id,
+                        is_active=True)
+            user.set_password('teacher123')
+            db.session.add(user)
+            db.session.commit()
+            teacher = Teacher(user_id=user.id,
+                              employee_number=f"TCH{i:03d}",
+                              department="Général",
+                              hire_date=date.today())
+            db.session.add(teacher)
+            teachers.append(teacher)
+        else:
+            teachers.append(Teacher.query.join(User).filter(User.email==email).first())
+    db.session.commit()
+
+    # Specific teacher for testing
+    if not User.query.filter_by(email='gbtexfares@gmail.com').first():
+        user = User(email='gbtexfares@gmail.com',
+                    first_name='Test',
+                    last_name='Teacher',
+                    role_id=teacher_role.id,
+                    is_active=True)
+        user.set_password('teacher123')
+        db.session.add(user)
+        db.session.commit()
+        teacher_profile = Teacher(user_id=user.id,
+                                  employee_number='TCH900',
+                                  department='Général',
+                                  hire_date=date.today())
+        db.session.add(teacher_profile)
+        teachers.append(teacher_profile)
+        db.session.commit()
+    else:
+        teachers.append(Teacher.query.join(User).filter(User.email=='gbtexfares@gmail.com').first())
+    # Students
+    class_groups = ['6A','6B','6C','5A','5B','5C','4A','4B','4C','3A','3B','3C']
+    students = []
+    for i in range(1, 101):
+        email = f"student{i}@school.fr"
+        if not User.query.filter_by(email=email).first():
+            user = User(email=email,
+                        first_name=f"Eleve{i}",
+                        last_name="Demo",
+                        role_id=student_role.id,
+                        is_active=True)
+            user.set_password('student123')
+            db.session.add(user)
+            db.session.commit()
+            profile = Student(user_id=user.id,
+                               student_number=f"STU{i:03d}",
+                               class_name=random.choice(class_groups),
+                               enrollment_date=date.today())
+            db.session.add(profile)
+            students.append(profile)
+        else:
+            students.append(Student.query.join(User).filter(User.email==email).first())
+    db.session.commit()
+
+    # Specific student for testing
+    if not User.query.filter_by(email='dossoufares@gmail.com').first():
+        user = User(email='dossoufares@gmail.com',
+                    first_name='Fares',
+                    last_name='Dossou',
+                    role_id=student_role.id,
+                    is_active=True)
+        user.set_password('student123')
+        db.session.add(user)
+        db.session.commit()
+        student_profile = Student(user_id=user.id,
+                                  student_number='STU900',
+                                  class_name='6A',
+                                  enrollment_date=date.today())
+        db.session.add(student_profile)
+        students.append(student_profile)
+        db.session.commit()
+    else:
+        students.append(Student.query.join(User).filter(User.email=='dossoufares@gmail.com').first())
+    # Parents
+    parents = []
+    for i in range(1, 51):
+        email = f"parent{i}@mail.fr"
+        if not User.query.filter_by(email=email).first():
+            user = User(email=email,
+                        first_name=f"Parent{i}",
+                        last_name="Demo",
+                        role_id=parent_role.id,
+                        is_active=True)
+            user.set_password('parent123')
+            db.session.add(user)
+            db.session.commit()
+            profile = Parent(user_id=user.id)
+            db.session.add(profile)
+            parents.append(profile)
+        else:
+            parents.append(Parent.query.join(User).filter(User.email==email).first())
+    db.session.commit()
+
+    # Specific parent for testing
+    if not User.query.filter_by(email='mlalarochelle17x@gmail.com').first():
+        user = User(email='mlalarochelle17x@gmail.com',
+                    first_name='Test',
+                    last_name='Parent',
+                    role_id=parent_role.id,
+                    is_active=True)
+        user.set_password('parent123')
+        db.session.add(user)
+        db.session.commit()
+        parent_profile = Parent(user_id=user.id)
+        db.session.add(parent_profile)
+        parents.append(parent_profile)
+        db.session.commit()
+        if students and not ParentStudent.query.filter_by(parent_id=parent_profile.id, student_id=students[0].id).first():
+            link = ParentStudent(parent_id=parent_profile.id, student_id=students[0].id, relationship_type="parent")
+            db.session.add(link)
+            db.session.commit()
+    else:
+        parent_profile = Parent.query.join(User).filter(User.email=='mlalarochelle17x@gmail.com').first()
+        parents.append(parent_profile)
+    # Link parents to students (2 students per parent when possible)
+    for idx, parent in enumerate(parents):
+        child_indices = [idx*2, idx*2+1]
+        for ci in child_indices:
+            if ci < len(students):
+                if not ParentStudent.query.filter_by(parent_id=parent.id, student_id=students[ci].id).first():
+                    link = ParentStudent(parent_id=parent.id, student_id=students[ci].id, relationship_type='parent')
+                    db.session.add(link)
+    db.session.commit()
+
+    # Courses
+    course_names = [
+        "Français",
+        "Mathématiques",
+        "Histoire-géographie",
+        "Enseignement moral et civique",
+        "Langues vivantes",
+        "Sciences de la vie et de la Terre",
+        "Physique-chimie",
+        "Technologie",
+        "Éducation physique et sportive",
+        "Arts plastiques",
+        "Éducation musicale"
     ]
-    
-    teacher_martin = Teacher.query.join(User).filter(User.email == 'prof.martin@school.fr').first()
-    teacher_durand = Teacher.query.join(User).filter(User.email == 'prof.durand@school.fr').first()
-    teacher_bernard = Teacher.query.join(User).filter(User.email == 'prof.bernard@school.fr').first()
-    
-    teachers = [teacher_martin, teacher_durand, teacher_bernard]
-    
-    for i, (name, code, desc, credits) in enumerate(courses_data):
-        if not Course.query.filter_by(code=code).first() and teachers[i]:
-            course = Course(
-                name=name,
-                code=code,
-                description=desc,
-                credits=credits,
-                teacher_id=teachers[i].id
-            )
+    courses = []
+    for idx, name in enumerate(course_names, start=1):
+        code = f"COUR{idx:03d}"
+        if not Course.query.filter_by(code=code).first():
+            teacher = teachers[(idx-1) % len(teachers)]
+            course = Course(name=name, code=code, description=f"Cours de {name}", credits=1, teacher_id=teacher.id)
             db.session.add(course)
-    
+            courses.append(course)
+        else:
+            courses.append(Course.query.filter_by(code=code).first())
     db.session.commit()
-    
-    print("Données d'exemple créées avec succès !")
-    print("Comptes de test créés :")
-    print("Admin: admin@school.fr / admin123")
-    print("Professeur: prof.martin@school.fr / teacher123") 
-    print("Étudiant: etudiant.dupont@school.fr / student123")
-    print("Parent: parent.dupont@email.fr / parent123")
+
+    # Schedules (one random slot per course and class)
+    days = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi"]
+    time_slots = [(time(8,0), time(9,0)), (time(9,0), time(10,0)), (time(10,0), time(11,0)), (time(11,0), time(12,0))]
+    for course in courses:
+        for group in class_groups:
+            start, end = random.choice(time_slots)
+            sched = Schedule(course_id=course.id,
+                             day_of_week=random.choice(days),
+                             start_time=start,
+                             end_time=end,
+                             classroom=f"{random.randint(1,20)}A",
+                             class_group=group)
+            db.session.add(sched)
+    db.session.commit()
+
+    # Grades (one grade per student per course)
+    for student in students:
+        for course in courses:
+            grade = Grade(student_id=student.id,
+                          course_id=course.id,
+                          grade_value=round(random.uniform(5, 20), 2),
+                          grade_type="Contrôle",
+                          date_recorded=datetime.utcnow(),
+                          teacher_id=course.teacher_id,
+                          comments="")
+            db.session.add(grade)
+    db.session.commit()
+
+    # Absences (0-2 random absences per student)
+    for student in students:
+        for _ in range(random.randint(0, 2)):
+            absence = Absence(student_id=student.id,
+                              date=date.today() - timedelta(days=random.randint(1, 30)),
+                              period='Journée',
+                              is_justified=random.choice([True, False]),
+                              reason='Maladie',
+                              teacher_id=random.choice(teachers).id)
+            db.session.add(absence)
+    db.session.commit()
+
+    print("Données de démonstration créées")
+


### PR DESCRIPTION
## Summary
- expand `create_sample_data` to generate many demo entries
- allow creation of courses, schedules, grades and absences for testing
- add dedicated demo accounts for easier testing

## Testing
- `PYTHONPATH=. pytest -q` *(fails: TemplateNotFound, DetachedInstanceError)*

------
https://chatgpt.com/codex/tasks/task_e_68888933abfc8329a8dda3ae22a40c18