### PR TITLE
Fix login page test credentials

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -73,24 +73,24 @@
                 <div class="row">
                     <div class="col-6">
                         <strong>Admin :</strong><br>
-                        admin@school.fr<br>
+                        ulbis047@gmail.com<br>
                         admin123
                     </div>
                     <div class="col-6">
                         <strong>Professeur :</strong><br>
-                        prof.martin@school.fr<br>
+                        gbtexfares@gmail.com<br>
                         teacher123
                     </div>
                 </div>
                 <div class="row mt-2">
                     <div class="col-6">
                         <strong>Étudiant :</strong><br>
-                        etudiant.dupont@school.fr<br>
+                        dossoufares@gmail.com<br>
                         student123
                     </div>
                     <div class="col-6">
                         <strong>Parent :</strong><br>
-                        parent.dupont@email.fr<br>
+                        mlalarochelle17x@gmail.com<br>
                         parent123
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update the example accounts shown on the login page to match README

## Testing
- `SECRET_KEY=testing PYTHONPATH=. pytest -q` *(fails: jinja2.exceptions.TemplateNotFound: auth/register.html)*

------
https://chatgpt.com/codex/tasks/task_e_688895b4c9348329ab63f8423a08502d