### PR TITLE
Fix missing templates

### DIFF
--- a/templates/main/profile.html
+++ b/templates/main/profile.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Mon Profil{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0"><i class="bi bi-person me-2"></i>Mon Profil</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item"><strong>Prénom :</strong> {{ current_user.first_name }}</li>
+                    <li class="list-group-item"><strong>Nom :</strong> {{ current_user.last_name }}</li>
+                    <li class="list-group-item"><strong>Email :</strong> {{ current_user.email }}</li>
+                    <li class="list-group-item"><strong>Rôle :</strong> {{ current_user.role.name }}</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/student/grades.html
+++ b/templates/student/grades.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Mes Notes{% endblock %}
+
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-clipboard-data me-2"></i>Mes Notes</h2>
+{% if grades %}
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Matière</th>
+                <th>Note</th>
+                <th>Type</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for grade in grades %}
+            <tr>
+                <td>{{ grade.course.name }}</td>
+                <td>
+                    <span class="badge bg-{{ 'success' if grade.grade_value >= 10 else 'danger' }}">
+                        {{ "%.1f"|format(grade.grade_value) }}/20
+                    </span>
+                </td>
+                <td>{{ grade.grade_type }}</td>
+                <td>{{ grade.date_recorded.strftime('%d/%m/%Y') }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted">Aucune note enregistrée.</p>
+{% endif %}
+{% endblock %}

--- a/templates/student/schedule.html
+++ b/templates/student/schedule.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}Mon Emploi du Temps{% endblock %}
+
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-calendar3 me-2"></i>Mon Emploi du Temps</h2>
+{% if schedules %}
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Jour</th>
+                <th>Début</th>
+                <th>Fin</th>
+                <th>Matière</th>
+                <th>Salle</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for sched in schedules %}
+            <tr>
+                <td>{{ sched.day_of_week }}</td>
+                <td>{{ sched.start_time.strftime('%H:%M') }}</td>
+                <td>{{ sched.end_time.strftime('%H:%M') }}</td>
+                <td>{{ sched.course.name }}</td>
+                <td>{{ sched.classroom }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted">Aucun emploi du temps disponible.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add missing templates for grades, schedule and profile

## Testing
- `pip install -r requirements.txt`
- `SECRET_KEY=test PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b0f759588329924cc566d90ff522