### PR TITLE
Translate website interface to English

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -5,26 +5,26 @@ from models import User, Role, Student, Teacher
 
 class LoginForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
-    password = PasswordField('Mot de passe', validators=[DataRequired()])
-    remember_me = BooleanField('Se souvenir de moi')
-    submit = SubmitField('Se connecter')
+    password = PasswordField('Password', validators=[DataRequired()])
+    remember_me = BooleanField('Remember me')
+    submit = SubmitField('Log in')
 
 class MFAForm(FlaskForm):
     # Allow codes up to 16 characters for tests and future extensions
-    code = StringField('Code de vérification', validators=[DataRequired(), Length(min=6, max=16)])
-    remember_me = BooleanField('Se souvenir de moi')
-    submit = SubmitField('Vérifier')
+    code = StringField('Verification code', validators=[DataRequired(), Length(min=6, max=16)])
+    remember_me = BooleanField('Remember me')
+    submit = SubmitField('Verify')
 
 class RegisterForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
-    first_name = StringField('Prénom', validators=[DataRequired(), Length(min=2, max=50)])
-    last_name = StringField('Nom', validators=[DataRequired(), Length(min=2, max=50)])
-    phone = StringField('Téléphone', validators=[Optional(), Length(max=20)])
-    password = PasswordField('Mot de passe', validators=[DataRequired(), Length(min=8)])
-    password2 = PasswordField('Confirmer le mot de passe', 
+    first_name = StringField('First name', validators=[DataRequired(), Length(min=2, max=50)])
+    last_name = StringField('Last name', validators=[DataRequired(), Length(min=2, max=50)])
+    phone = StringField('Phone', validators=[Optional(), Length(max=20)])
+    password = PasswordField('Password', validators=[DataRequired(), Length(min=8)])
+    password2 = PasswordField('Confirm password',
                              validators=[DataRequired(), EqualTo('password')])
-    role_id = SelectField('Rôle', coerce=int, validators=[DataRequired()])
-    submit = SubmitField('S\'inscrire')
+    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
+    submit = SubmitField('Sign up')
     
     def __init__(self, *args, **kwargs):
         super(RegisterForm, self).__init__(*args, **kwargs)
@@ -33,30 +33,30 @@ class RegisterForm(FlaskForm):
     def validate_email(self, email):
         user = User.query.filter_by(email=email.data).first()
         if user is not None:
-            raise ValidationError('Cette adresse email est déjà utilisée.')
+            raise ValidationError('This email address is already in use.')
 
 class UserForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
-    first_name = StringField('Prénom', validators=[DataRequired(), Length(min=2, max=50)])
-    last_name = StringField('Nom', validators=[DataRequired(), Length(min=2, max=50)])
-    phone = StringField('Téléphone', validators=[Optional(), Length(max=20)])
-    password = PasswordField('Mot de passe', validators=[Optional(), Length(min=8)])
-    role_id = SelectField('Rôle', coerce=int, validators=[DataRequired()])
-    is_active = BooleanField('Compte actif', default=True)
-    submit = SubmitField('Enregistrer')
+    first_name = StringField('First name', validators=[DataRequired(), Length(min=2, max=50)])
+    last_name = StringField('Last name', validators=[DataRequired(), Length(min=2, max=50)])
+    phone = StringField('Phone', validators=[Optional(), Length(max=20)])
+    password = PasswordField('Password', validators=[Optional(), Length(min=8)])
+    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
+    is_active = BooleanField('Active account', default=True)
+    submit = SubmitField('Save')
 
 class GradeForm(FlaskForm):
-    student_id = SelectField('Étudiant', coerce=int, validators=[DataRequired()])
-    course_id = SelectField('Matière', coerce=int, validators=[DataRequired()])
-    grade_value = FloatField('Note', validators=[DataRequired(), NumberRange(min=0, max=20)])
+    student_id = SelectField('Student', coerce=int, validators=[DataRequired()])
+    course_id = SelectField('Course', coerce=int, validators=[DataRequired()])
+    grade_value = FloatField('Grade', validators=[DataRequired(), NumberRange(min=0, max=20)])
     grade_type = SelectField('Type', choices=[
-        ('Contrôle', 'Contrôle'),
-        ('Examen', 'Examen'),
-        ('Devoir', 'Devoir'),
+        ('Test', 'Test'),
+        ('Exam', 'Exam'),
+        ('Homework', 'Homework'),
         ('Participation', 'Participation')
     ], validators=[DataRequired()])
-    comments = TextAreaField('Commentaires', validators=[Optional()])
-    submit = SubmitField('Ajouter la note')
+    comments = TextAreaField('Comments', validators=[Optional()])
+    submit = SubmitField('Add grade')
     
     def __init__(self, *args, **kwargs):
         super(GradeForm, self).__init__(*args, **kwargs)
@@ -64,16 +64,16 @@ class GradeForm(FlaskForm):
                                   for s in Student.query.join(User)]
 
 class AbsenceForm(FlaskForm):
-    student_id = SelectField('Étudiant', coerce=int, validators=[DataRequired()])
+    student_id = SelectField('Student', coerce=int, validators=[DataRequired()])
     date = DateField('Date', validators=[DataRequired()])
-    period = SelectField('Période', choices=[
-        ('Matin', 'Matin'),
-        ('Après-midi', 'Après-midi'),
-        ('Journée', 'Journée complète')
+    period = SelectField('Period', choices=[
+        ('Morning', 'Morning'),
+        ('Afternoon', 'Afternoon'),
+        ('Day', 'Full day')
     ], validators=[DataRequired()])
-    is_justified = BooleanField('Absence justifiée', default=False)
-    reason = StringField('Motif', validators=[Optional(), Length(max=200)])
-    submit = SubmitField('Enregistrer l\'absence')
+    is_justified = BooleanField('Justified absence', default=False)
+    reason = StringField('Reason', validators=[Optional(), Length(max=200)])
+    submit = SubmitField("Save absence")
     
     def __init__(self, *args, **kwargs):
         super(AbsenceForm, self).__init__(*args, **kwargs)
@@ -81,9 +81,9 @@ class AbsenceForm(FlaskForm):
                                   for s in Student.query.join(User)]
 
 class CourseForm(FlaskForm):
-    name = StringField('Nom du cours', validators=[DataRequired(), Length(max=100)])
+    name = StringField('Course name', validators=[DataRequired(), Length(max=100)])
     code = StringField('Code', validators=[DataRequired(), Length(max=20)])
     description = TextAreaField('Description', validators=[Optional()])
-    credits = IntegerField('Crédits', validators=[DataRequired(), NumberRange(min=1, max=10)])
-    teacher_id = SelectField('Professeur', coerce=int, validators=[DataRequired()])
-    submit = SubmitField('Enregistrer')
+    credits = IntegerField('Credits', validators=[DataRequired(), NumberRange(min=1, max=10)])
+    teacher_id = SelectField('Teacher', coerce=int, validators=[DataRequired()])
+    submit = SubmitField('Save')

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 
-{% block title %}Tableau de bord Administrateur{% endblock %}
+{% block title %}Administrator Dashboard{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2><i class="bi bi-gear-fill me-2"></i>Tableau de bord Administrateur</h2>
+    <h2><i class="bi bi-gear-fill me-2"></i>Administrator Dashboard</h2>
     <span class="badge bg-danger fs-6">Administration</span>
 </div>
 
-<!-- Statistiques globales -->
+<!-- Global statistics -->
 <div class="row mb-4">
     <div class="col-xl-3 col-md-6 mb-3">
         <div class="card bg-primary text-white">
             <div class="card-body">
                 <div class="d-flex align-items-center">
                     <div class="flex-grow-1">
-                        <h6 class="text-white-50">Total Utilisateurs</h6>
+                        <h6 class="text-white-50">Total Users</h6>
                         <h3 class="mb-0">{{ stats.total_users }}</h3>
                     </div>
                     <div class="flex-shrink-0">
@@ -31,7 +31,7 @@
             <div class="card-body">
                 <div class="d-flex align-items-center">
                     <div class="flex-grow-1">
-                        <h6 class="text-white-50">Étudiants</h6>
+                        <h6 class="text-white-50">Students</h6>
                         <h3 class="mb-0">{{ stats.total_students }}</h3>
                     </div>
                     <div class="flex-shrink-0">
@@ -47,7 +47,7 @@
             <div class="card-body">
                 <div class="d-flex align-items-center">
                     <div class="flex-grow-1">
-                        <h6 class="text-white-50">Professeurs</h6>
+                        <h6 class="text-white-50">Teachers</h6>
                         <h3 class="mb-0">{{ stats.total_teachers }}</h3>
                     </div>
                     <div class="flex-shrink-0">
@@ -63,7 +63,7 @@
             <div class="card-body">
                 <div class="d-flex align-items-center">
                     <div class="flex-grow-1">
-                        <h6 class="text-white-50">Cours</h6>
+                        <h6 class="text-white-50">Courses</h6>
                         <h3 class="mb-0">{{ stats.total_courses }}</h3>
                     </div>
                     <div class="flex-shrink-0">
@@ -81,7 +81,7 @@
             <div class="card-header bg-primary text-white">
                 <h5 class="mb-0">
                     <i class="bi bi-person-plus me-2"></i>
-                    Utilisateurs récents
+                    Recent users
                 </h5>
             </div>
             <div class="card-body">
@@ -90,11 +90,11 @@
                         <table class="table table-sm">
                             <thead>
                                 <tr>
-                                    <th>Nom</th>
+                                    <th>Name</th>
                                     <th>Email</th>
-                                    <th>Rôle</th>
-                                    <th>Date création</th>
-                                    <th>Statut</th>
+                                    <th>Role</th>
+                                    <th>Created</th>
+                                    <th>Status</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -117,7 +117,7 @@
                         </table>
                     </div>
                 {% else %}
-                    <p class="text-muted text-center py-3">Aucun utilisateur récent</p>
+                    <p class="text-muted text-center py-3">No recent users</p>
                 {% endif %}
             </div>
         </div>
@@ -128,26 +128,26 @@
             <div class="card-header bg-success text-white">
                 <h5 class="mb-0">
                     <i class="bi bi-lightning me-2"></i>
-                    Actions rapides
+                    Quick actions
                 </h5>
             </div>
             <div class="card-body">
                 <div class="d-grid gap-2">
                     <a href="{{ url_for('admin.add_user') }}" class="btn btn-outline-primary">
                         <i class="bi bi-person-plus me-2"></i>
-                        Ajouter un utilisateur
+                        Add a user
                     </a>
                     <a href="{{ url_for('admin.add_course') }}" class="btn btn-outline-success">
                         <i class="bi bi-journal-plus me-2"></i>
-                        Créer un cours
+                        Create a course
                     </a>
                     <a href="{{ url_for('admin.users') }}" class="btn btn-outline-info">
                         <i class="bi bi-people me-2"></i>
-                        Gérer les utilisateurs
+                        Manage users
                     </a>
                     <a href="{{ url_for('admin.courses') }}" class="btn btn-outline-warning">
                         <i class="bi bi-book me-2"></i>
-                        Gérer les cours
+                        Manage courses
                     </a>
                 </div>
             </div>
@@ -157,33 +157,33 @@
             <div class="card-header bg-warning text-dark">
                 <h6 class="mb-0">
                     <i class="bi bi-tools me-2"></i>
-                    Outils de développement
+                    Development tools
                 </h6>
             </div>
             <div class="card-body">
                 <div class="d-grid">
                     <a href="{{ url_for('admin.init_sample_data') }}" class="btn btn-outline-warning btn-sm" 
-                       onclick="return confirm('Cela va créer des données d\'exemple. Continuer ?')">
+                       onclick="return confirm('This will create sample data. Continue?')">
                         <i class="bi bi-database-add me-2"></i>
-                        Initialiser données d'exemple
+                        Initialize sample data
                     </a>
                 </div>
                 <p class="text-muted small mt-2">
-                    Crée des utilisateurs, cours et données de test pour développement.
+                    Creates users, courses and test data for development purposes.
                 </p>
             </div>
         </div>
     </div>
 </div>
 
-<!-- Statistiques détaillées -->
+<!-- Detailed statistics -->
 <div class="row">
     <div class="col-12">
         <div class="card shadow-sm">
             <div class="card-header bg-light">
                 <h5 class="mb-0">
                     <i class="bi bi-bar-chart me-2"></i>
-                    Statistiques détaillées
+                    Detailed statistics
                 </h5>
             </div>
             <div class="card-body">
@@ -194,11 +194,11 @@
                     </div>
                     <div class="col-md-2 col-sm-4 mb-3">
                         <h4 class="text-success">{{ stats.total_students }}</h4>
-                        <p class="text-muted small">Étudiants</p>
+                        <p class="text-muted small">Students</p>
                     </div>
                     <div class="col-md-2 col-sm-4 mb-3">
                         <h4 class="text-warning">{{ stats.total_teachers }}</h4>
-                        <p class="text-muted small">Professeurs</p>
+                        <p class="text-muted small">Teachers</p>
                     </div>
                     <div class="col-md-2 col-sm-4 mb-3">
                         <h4 class="text-info">{{ stats.total_parents }}</h4>
@@ -206,11 +206,11 @@
                     </div>
                     <div class="col-md-2 col-sm-4 mb-3">
                         <h4 class="text-secondary">{{ stats.total_courses }}</h4>
-                        <p class="text-muted small">Cours</p>
+                        <p class="text-muted small">Courses</p>
                     </div>
                     <div class="col-md-2 col-sm-4 mb-3">
                         <h4 class="text-dark">{{ stats.total_grades }}</h4>
-                        <p class="text-muted small">Notes saisies</p>
+                        <p class="text-muted small">Grades entered</p>
                     </div>
                 </div>
             </div>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Connexion - Intranet Scolaire{% endblock %}
+{% block title %}Login - School Intranet{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">
@@ -9,7 +9,7 @@
             <div class="card-header bg-primary text-white text-center">
                 <h4 class="mb-0">
                     <i class="bi bi-box-arrow-in-right me-2"></i>
-                    Connexion
+                    Login
                 </h4>
             </div>
             <div class="card-body p-4">
@@ -52,8 +52,8 @@
                 
                 <div class="text-center mt-3">
                     <p class="text-muted">
-                        Pas encore de compte ? 
-                        <a href="{{ url_for('auth.register') }}" class="text-decoration-none">S'inscrire</a>
+                        Don't have an account?
+                        <a href="{{ url_for('auth.register') }}" class="text-decoration-none">Sign up</a>
                     </p>
                 </div>
             </div>
@@ -61,13 +61,13 @@
         
         <div class="alert alert-info mt-3">
             <i class="bi bi-info-circle me-2"></i>
-            <strong>Sécurité MFA :</strong> Après saisie de vos identifiants, un code de vérification sera envoyé à votre adresse email.
+            <strong>MFA security:</strong> After entering your credentials, a verification code will be sent to your email address.
         </div>
         
         <!-- Comptes de test -->
         <div class="card mt-3">
             <div class="card-header bg-light">
-                <h6 class="mb-0"><i class="bi bi-key me-2"></i>Comptes de test</h6>
+                <h6 class="mb-0"><i class="bi bi-key me-2"></i>Test accounts</h6>
             </div>
             <div class="card-body small">
                 <div class="row">
@@ -77,19 +77,19 @@
                         admin123
                     </div>
                     <div class="col-6">
-                        <strong>Professeur :</strong><br>
+                        <strong>Teacher:</strong><br>
                         gbtexfares@gmail.com<br>
                         teacher123
                     </div>
                 </div>
                 <div class="row mt-2">
                     <div class="col-6">
-                        <strong>Étudiant :</strong><br>
+                        <strong>Student:</strong><br>
                         dossoufares@gmail.com<br>
                         student123
                     </div>
                     <div class="col-6">
-                        <strong>Parent :</strong><br>
+                        <strong>Parent:</strong><br>
                         mlalarochelle17x@gmail.com<br>
                         parent123
                     </div>

--- a/templates/auth/mfa_verify.html
+++ b/templates/auth/mfa_verify.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Vérification MFA - Intranet Scolaire{% endblock %}
+{% block title %}MFA Verification - School Intranet{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">
@@ -9,14 +9,14 @@
             <div class="card-header bg-warning text-dark text-center">
                 <h4 class="mb-0">
                     <i class="bi bi-shield-lock me-2"></i>
-                    Vérification de sécurité
+                    Security Verification
                 </h4>
             </div>
             <div class="card-body p-4">
                 <div class="alert alert-info">
                     <i class="bi bi-envelope me-2"></i>
-                    Un code de vérification a été envoyé à votre adresse email. 
-                    Veuillez le saisir ci-dessous pour continuer.
+                    A verification code was sent to your email address.
+                    Please enter it below to continue.
                 </div>
                 
                 <form method="POST">
@@ -25,7 +25,7 @@
                     <div class="mb-3">
                         {{ form.code.label(class="form-label") }}
                             {{ form.code(class="form-control form-control-lg text-center" + (" is-invalid" if form.code.errors else ""),
-                                     placeholder="Entrez le code à 12 caractères", maxlength="12", autocomplete="off") }}
+                                     placeholder="Enter the 12-character code", maxlength="12", autocomplete="off") }}
                         {% if form.code.errors %}
                             <div class="invalid-feedback">
                                 {% for error in form.code.errors %}
@@ -48,11 +48,11 @@
                 <div class="text-center mt-3">
                     <p class="text-muted small">
                         <i class="bi bi-clock me-1"></i>
-                        Le code expire dans 10 minutes
+                        The code expires in 10 minutes
                     </p>
                     <a href="{{ url_for('auth.login') }}" class="text-decoration-none">
                         <i class="bi bi-arrow-left me-1"></i>
-                        Retour à la connexion
+                        Back to login
                     </a>
                 </div>
             </div>
@@ -60,7 +60,7 @@
         
         <div class="alert alert-warning mt-3">
             <i class="bi bi-exclamation-triangle me-2"></i>
-            <strong>Note de développement :</strong> En mode développement, le code MFA est visible dans les logs de l'application.
+            <strong>Development note:</strong> In development mode the MFA code is visible in the application logs.
         </div>
     </div>
 </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Inscription - Intranet Scolaire{% endblock %}
+{% block title %}Sign Up - School Intranet{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">
@@ -9,7 +9,7 @@
             <div class="card-header bg-success text-white text-center">
                 <h4 class="mb-0">
                     <i class="bi bi-person-plus me-2"></i>
-                    Inscription
+                    Sign Up
                 </h4>
             </div>
             <div class="card-body p-4">
@@ -70,7 +70,7 @@
                 </form>
                 <div class="text-center mt-3">
                     <p class="text-muted">
-                        Déjà inscrit ? <a href="{{ url_for('auth.login') }}" class="text-decoration-none">Se connecter</a>
+                        Already have an account? <a href="{{ url_for('auth.login') }}" class="text-decoration-none">Log in</a>
                     </p>
                 </div>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}Intranet Scolaire{% endblock %}</title>
+    <title>{% block title %}School Intranet{% endblock %}</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -18,7 +18,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
             <a class="navbar-brand" href="{{ url_for('main.index') }}">
-                <i class="bi bi-mortarboard me-2"></i>Intranet Scolaire
+                <i class="bi bi-mortarboard me-2"></i>School Intranet
             </a>
             
             {% if current_user.is_authenticated %}
@@ -30,19 +30,19 @@
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main.dashboard') }}">
-                            <i class="bi bi-house-door me-1"></i>Accueil
+                            <i class="bi bi-house-door me-1"></i>Home
                         </a>
                     </li>
                     
                     {% if current_user.has_role('student') %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('student.grades') }}">
-                            <i class="bi bi-clipboard-data me-1"></i>Mes Notes
+                            <i class="bi bi-clipboard-data me-1"></i>My Grades
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('student.schedule') }}">
-                            <i class="bi bi-calendar3 me-1"></i>Planning
+                            <i class="bi bi-calendar3 me-1"></i>Schedule
                         </a>
                     </li>
                     {% endif %}
@@ -50,12 +50,12 @@
                     {% if current_user.has_role('teacher') %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('teacher.courses') }}">
-                            <i class="bi bi-book me-1"></i>Mes Cours
+                            <i class="bi bi-book me-1"></i>My Courses
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('teacher.add_grade') }}">
-                            <i class="bi bi-plus-circle me-1"></i>Ajouter Note
+                            <i class="bi bi-plus-circle me-1"></i>Add Grade
                         </a>
                     </li>
                     {% endif %}
@@ -63,12 +63,12 @@
                     {% if current_user.has_role('admin') %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin.users') }}">
-                            <i class="bi bi-people me-1"></i>Utilisateurs
+                            <i class="bi bi-people me-1"></i>Users
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin.courses') }}">
-                            <i class="bi bi-journal-bookmark me-1"></i>Cours
+                            <i class="bi bi-journal-bookmark me-1"></i>Courses
                         </a>
                     </li>
                     {% endif %}
@@ -81,11 +81,11 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" href="{{ url_for('main.profile') }}">
-                                <i class="bi bi-person me-2"></i>Mon Profil
+                                <i class="bi bi-person me-2"></i>Profile
                             </a></li>
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ url_for('auth.logout') }}">
-                                <i class="bi bi-box-arrow-right me-2"></i>Déconnexion
+                                <i class="bi bi-box-arrow-right me-2"></i>Logout
                             </a></li>
                         </ul>
                     </li>
@@ -112,7 +112,7 @@
 
     <footer class="bg-light mt-5 py-4">
         <div class="container text-center">
-            <p class="text-muted mb-0">&copy; 2024 Intranet Scolaire. Tous droits réservés.</p>
+            <p class="text-muted mb-0">&copy; 2024 School Intranet. All rights reserved.</p>
         </div>
     </footer>
 

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}Page non trouvée - 404{% endblock %}
+{% block title %}Page not found - 404{% endblock %}
 
 {% block content %}
 <div class="text-center">
     <div class="py-5">
         <i class="bi bi-exclamation-triangle display-1 text-warning"></i>
         <h1 class="display-4 fw-bold">404</h1>
-        <p class="lead">La page que vous recherchez est introuvable.</p>
-        <p class="text-muted">Il se peut que la page ait été déplacée, supprimée ou que l'URL soit incorrecte.</p>
+        <p class="lead">The page you are looking for cannot be found.</p>
+        <p class="text-muted">It may have been moved, deleted or the URL is incorrect.</p>
         <div class="mt-4">
             <a href="{{ url_for('main.index') }}" class="btn btn-primary me-2">
-                <i class="bi bi-house me-2"></i>Retour à l'accueil
+                <i class="bi bi-house me-2"></i>Back to home
             </a>
             <a href="javascript:history.back()" class="btn btn-outline-secondary">
-                <i class="bi bi-arrow-left me-2"></i>Page précédente
+                <i class="bi bi-arrow-left me-2"></i>Previous page
             </a>
         </div>
     </div>

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}Erreur serveur - 500{% endblock %}
+{% block title %}Server error - 500{% endblock %}
 
 {% block content %}
 <div class="text-center">
     <div class="py-5">
         <i class="bi bi-exclamation-octagon display-1 text-danger"></i>
         <h1 class="display-4 fw-bold">500</h1>
-        <p class="lead">Une erreur interne du serveur s'est produite.</p>
-        <p class="text-muted">Nous nous excusons pour la gêne occasionnée. L'erreur a été signalée et sera corrigée rapidement.</p>
+        <p class="lead">An internal server error occurred.</p>
+        <p class="text-muted">We apologize for the inconvenience. The error has been reported and will be fixed shortly.</p>
         <div class="mt-4">
             <a href="{{ url_for('main.index') }}" class="btn btn-primary me-2">
-                <i class="bi bi-house me-2"></i>Retour à l'accueil
+                <i class="bi bi-house me-2"></i>Back to home
             </a>
             <button onclick="location.reload()" class="btn btn-outline-secondary">
-                <i class="bi bi-arrow-clockwise me-2"></i>Réessayer
+                <i class="bi bi-arrow-clockwise me-2"></i>Try again
             </button>
         </div>
     </div>

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -1,23 +1,23 @@
 {% extends "base.html" %}
 
-{% block title %}Accueil - Intranet Scolaire{% endblock %}
+{% block title %}Home - School Intranet{% endblock %}
 
 {% block content %}
 <div class="hero-section bg-primary text-white py-5 mb-5 rounded">
     <div class="container text-center">
         <h1 class="display-4 mb-4">
             <i class="bi bi-mortarboard me-3"></i>
-            Bienvenue sur l'Intranet Scolaire
+            Welcome to the School Intranet
         </h1>
         <p class="lead mb-4">
-            Plateforme sécurisée pour étudiants, parents, professeurs et administration
+            A secure platform for students, parents, teachers and administration
         </p>
         {% if not current_user.is_authenticated %}
         <a href="{{ url_for('auth.login') }}" class="btn btn-light btn-lg me-3">
-            <i class="bi bi-box-arrow-in-right me-2"></i>Se connecter
+            <i class="bi bi-box-arrow-in-right me-2"></i>Log in
         </a>
         <a href="{{ url_for('auth.register') }}" class="btn btn-outline-light btn-lg">
-            <i class="bi bi-person-plus me-2"></i>S'inscrire
+            <i class="bi bi-person-plus me-2"></i>Sign up
         </a>
         {% endif %}
     </div>
@@ -30,8 +30,8 @@
                 <div class="feature-icon bg-primary text-white rounded-circle d-inline-flex align-items-center justify-content-center mb-3">
                     <i class="bi bi-people fs-3"></i>
                 </div>
-                <h5 class="card-title">Étudiants</h5>
-                <p class="card-text">Consultez vos notes, votre emploi du temps et vos absences en toute simplicité.</p>
+                <h5 class="card-title">Students</h5>
+                <p class="card-text">Check your grades, schedule and absences easily.</p>
             </div>
         </div>
     </div>
@@ -43,7 +43,7 @@
                     <i class="bi bi-heart fs-3"></i>
                 </div>
                 <h5 class="card-title">Parents</h5>
-                <p class="card-text">Suivez la scolarité de vos enfants : notes, absences et communication avec l'école.</p>
+                <p class="card-text">Follow your children's schooling: grades, absences and communication with the school.</p>
             </div>
         </div>
     </div>
@@ -54,8 +54,8 @@
                 <div class="feature-icon bg-warning text-white rounded-circle d-inline-flex align-items-center justify-content-center mb-3">
                     <i class="bi bi-journal-bookmark fs-3"></i>
                 </div>
-                <h5 class="card-title">Professeurs</h5>
-                <p class="card-text">Gérez vos classes, saisissez les notes et marquez les absences efficacement.</p>
+                <h5 class="card-title">Teachers</h5>
+                <p class="card-text">Manage your classes, enter grades and mark absences efficiently.</p>
             </div>
         </div>
     </div>
@@ -67,7 +67,7 @@
                     <i class="bi bi-gear fs-3"></i>
                 </div>
                 <h5 class="card-title">Administration</h5>
-                <p class="card-text">Administrez les utilisateurs, les cours et consultez les statistiques globales.</p>
+                <p class="card-text">Manage users and courses and view global statistics.</p>
             </div>
         </div>
     </div>
@@ -75,27 +75,27 @@
 
 <div class="row mt-5">
     <div class="col-md-8 mx-auto text-center">
-        <h3 class="mb-4">Sécurité et Simplicité</h3>
+        <h3 class="mb-4">Security and Simplicity</h3>
         <p class="lead text-muted">
-            Notre intranet utilise une authentification multi-facteurs (MFA) pour garantir la sécurité de vos données. 
-            Une interface intuitive permet à chaque utilisateur d'accéder facilement aux fonctionnalités qui lui sont destinées.
+            Our intranet uses multi-factor authentication (MFA) to keep your data safe.
+            An intuitive interface allows each user to easily access the features they need.
         </p>
         
         <div class="row mt-4">
             <div class="col-md-4 mb-3">
                 <i class="bi bi-shield-check text-primary fs-1"></i>
-                <h6 class="mt-2">Sécurité MFA</h6>
-                <p class="text-muted small">Authentification à deux facteurs par email</p>
+                <h6 class="mt-2">MFA Security</h6>
+                <p class="text-muted small">Two-factor authentication via email</p>
             </div>
             <div class="col-md-4 mb-3">
                 <i class="bi bi-phone text-primary fs-1"></i>
-                <h6 class="mt-2">Interface Responsive</h6>
-                <p class="text-muted small">Accessible sur tous vos appareils</p>
+                <h6 class="mt-2">Responsive Interface</h6>
+                <p class="text-muted small">Accessible on all your devices</p>
             </div>
             <div class="col-md-4 mb-3">
                 <i class="bi bi-clock text-primary fs-1"></i>
-                <h6 class="mt-2">Disponible 24/7</h6>
-                <p class="text-muted small">Accès permanent à vos informations</p>
+                <h6 class="mt-2">Available 24/7</h6>
+                <p class="text-muted small">Access your information at any time</p>
             </div>
         </div>
     </div>

--- a/templates/main/profile.html
+++ b/templates/main/profile.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}Mon Profil{% endblock %}
+{% block title %}My Profile{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-md-6">
         <div class="card shadow-sm">
             <div class="card-header bg-primary text-white">
-                <h5 class="mb-0"><i class="bi bi-person me-2"></i>Mon Profil</h5>
+                <h5 class="mb-0"><i class="bi bi-person me-2"></i>My Profile</h5>
             </div>
             <div class="card-body">
                 <ul class="list-group list-group-flush">
-                    <li class="list-group-item"><strong>Prénom :</strong> {{ current_user.first_name }}</li>
-                    <li class="list-group-item"><strong>Nom :</strong> {{ current_user.last_name }}</li>
-                    <li class="list-group-item"><strong>Email :</strong> {{ current_user.email }}</li>
-                    <li class="list-group-item"><strong>Rôle :</strong> {{ current_user.role.name }}</li>
+                    <li class="list-group-item"><strong>First name:</strong> {{ current_user.first_name }}</li>
+                    <li class="list-group-item"><strong>Last name:</strong> {{ current_user.last_name }}</li>
+                    <li class="list-group-item"><strong>Email:</strong> {{ current_user.email }}</li>
+                    <li class="list-group-item"><strong>Role:</strong> {{ current_user.role.name }}</li>
                 </ul>
             </div>
         </div>

--- a/templates/parent/dashboard.html
+++ b/templates/parent/dashboard.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Tableau de bord Parent{% endblock %}
+{% block title %}Parent Dashboard{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2><i class="bi bi-people me-2"></i>Bonjour {{ current_user.first_name }} !</h2>
+    <h2><i class="bi bi-people me-2"></i>Hello {{ current_user.first_name }}!</h2>
     <span class="badge bg-success fs-6">Parent</span>
 </div>
 
@@ -18,7 +18,7 @@
                 <span class="badge bg-secondary ms-2">{{ child.student.class_name }}</span>
             </div>
             <div class="card-body">
-                <p><strong>Notes récentes :</strong></p>
+                <p><strong>Recent grades:</strong></p>
                 {% if child.recent_grades %}
                 <ul class="list-unstyled mb-3">
                     {% for grade in child.recent_grades %}
@@ -26,10 +26,10 @@
                     {% endfor %}
                 </ul>
                 {% else %}
-                <p class="text-muted">Aucune note.</p>
+                <p class="text-muted">No grades.</p>
                 {% endif %}
 
-                <p><strong>Absences récentes :</strong></p>
+                <p><strong>Recent absences:</strong></p>
                 {% if child.recent_absences %}
                 <ul class="list-unstyled mb-0">
                     {% for absence in child.recent_absences %}
@@ -37,12 +37,12 @@
                     {% endfor %}
                 </ul>
                 {% else %}
-                <p class="text-muted">Aucune absence.</p>
+                <p class="text-muted">No absences.</p>
                 {% endif %}
             </div>
             <div class="card-footer text-center bg-white">
-                <a href="{{ url_for('parent.child_grades', student_id=child.student.id) }}" class="btn btn-sm btn-outline-primary me-2">Notes</a>
-                <a href="{{ url_for('parent.child_schedule', student_id=child.student.id) }}" class="btn btn-sm btn-outline-success me-2">Planning</a>
+                <a href="{{ url_for('parent.child_grades', student_id=child.student.id) }}" class="btn btn-sm btn-outline-primary me-2">Grades</a>
+                <a href="{{ url_for('parent.child_schedule', student_id=child.student.id) }}" class="btn btn-sm btn-outline-success me-2">Schedule</a>
                 <a href="{{ url_for('parent.child_absences', student_id=child.student.id) }}" class="btn btn-sm btn-outline-warning">Absences</a>
             </div>
         </div>
@@ -50,6 +50,6 @@
     {% endfor %}
 </div>
 {% else %}
-<p class="text-muted">Aucun enfant associé à ce compte.</p>
+<p class="text-muted">No child associated with this account.</p>
 {% endif %}
 {% endblock %}

--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Tableau de bord Étudiant - {{ current_user.first_name }}{% endblock %}
+{% block title %}Student Dashboard - {{ current_user.first_name }}{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2><i class="bi bi-mortarboard me-2"></i>Bonjour {{ current_user.first_name }} !</h2>
-    <span class="badge bg-primary fs-6">Étudiant - {{ student.class_name }}</span>
+    <h2><i class="bi bi-mortarboard me-2"></i>Hello {{ current_user.first_name }}!</h2>
+    <span class="badge bg-primary fs-6">Student - {{ student.class_name }}</span>
 </div>
 
 <!-- Statistiques -->
@@ -15,7 +15,7 @@
             <div class="card-body text-center">
                 <i class="bi bi-clipboard-data fs-1"></i>
                 <h4>{{ total_grades }}</h4>
-                <p class="mb-0">Notes</p>
+                <p class="mb-0">Grades</p>
             </div>
         </div>
     </div>
@@ -33,7 +33,7 @@
             <div class="card-body text-center">
                 <i class="bi bi-book fs-1"></i>
                 <h4>{{ student.class_name }}</h4>
-                <p class="mb-0">Classe</p>
+                <p class="mb-0">Class</p>
             </div>
         </div>
     </div>
@@ -42,7 +42,7 @@
             <div class="card-body text-center">
                 <i class="bi bi-person-badge fs-1"></i>
                 <h4>{{ student.student_number }}</h4>
-                <p class="mb-0">N° Étudiant</p>
+                <p class="mb-0">Student No.</p>
             </div>
         </div>
     </div>
@@ -54,7 +54,7 @@
             <div class="card-header bg-primary text-white">
                 <h5 class="mb-0">
                     <i class="bi bi-clipboard-data me-2"></i>
-                    Dernières notes
+                    Latest grades
                 </h5>
             </div>
             <div class="card-body">
@@ -87,13 +87,13 @@
                     </div>
                     <div class="text-center mt-3">
                         <a href="{{ url_for('student.grades') }}" class="btn btn-primary btn-sm">
-                            Voir toutes mes notes
+                            View all my grades
                         </a>
                     </div>
                 {% else %}
                     <p class="text-muted text-center py-3">
                         <i class="bi bi-clipboard-x fs-1 d-block mb-2"></i>
-                        Aucune note enregistrée
+                        No grades recorded
                     </p>
                 {% endif %}
             </div>
@@ -105,7 +105,7 @@
             <div class="card-header bg-warning text-dark">
                 <h5 class="mb-0">
                     <i class="bi bi-calendar-x me-2"></i>
-                    Absences récentes
+                    Recent absences
                 </h5>
             </div>
             <div class="card-body">
@@ -126,7 +126,7 @@
                                     <td>{{ absence.period }}</td>
                                     <td>
                                         <span class="badge bg-{{ 'success' if absence.is_justified else 'warning' }}">
-                                            {{ 'Justifiée' if absence.is_justified else 'Non justifiée' }}
+                                            {{ 'Justified' if absence.is_justified else 'Unjustified' }}
                                         </span>
                                     </td>
                                 </tr>
@@ -136,13 +136,13 @@
                     </div>
                     <div class="text-center mt-3">
                         <a href="{{ url_for('student.absences') }}" class="btn btn-warning btn-sm">
-                            Voir toutes mes absences
+                            View all my absences
                         </a>
                     </div>
                 {% else %}
                     <p class="text-muted text-center py-3">
                         <i class="bi bi-check-circle fs-1 d-block mb-2"></i>
-                        Aucune absence enregistrée
+                        No absences recorded
                     </p>
                 {% endif %}
             </div>
@@ -150,14 +150,14 @@
     </div>
 </div>
 
-<!-- Actions rapides -->
+<!-- Quick actions -->
 <div class="row">
     <div class="col-12">
         <div class="card shadow-sm">
             <div class="card-header bg-light">
                 <h5 class="mb-0">
                     <i class="bi bi-lightning me-2"></i>
-                    Actions rapides
+                    Quick actions
                 </h5>
             </div>
             <div class="card-body">
@@ -166,8 +166,8 @@
                         <a href="{{ url_for('student.grades') }}" class="card text-decoration-none h-100">
                             <div class="card-body text-center">
                                 <i class="bi bi-clipboard-data text-primary fs-1"></i>
-                                <h6 class="mt-2">Consulter mes notes</h6>
-                                <p class="text-muted small">Voir toutes mes évaluations</p>
+                                <h6 class="mt-2">View my grades</h6>
+                                <p class="text-muted small">See all my evaluations</p>
                             </div>
                         </a>
                     </div>
@@ -175,8 +175,8 @@
                         <a href="{{ url_for('student.schedule') }}" class="card text-decoration-none h-100">
                             <div class="card-body text-center">
                                 <i class="bi bi-calendar3 text-success fs-1"></i>
-                                <h6 class="mt-2">Mon emploi du temps</h6>
-                                <p class="text-muted small">Planning des cours</p>
+                                <h6 class="mt-2">My schedule</h6>
+                                <p class="text-muted small">Course timetable</p>
                             </div>
                         </a>
                     </div>
@@ -184,8 +184,8 @@
                         <a href="{{ url_for('main.profile') }}" class="card text-decoration-none h-100">
                             <div class="card-body text-center">
                                 <i class="bi bi-person-circle text-info fs-1"></i>
-                                <h6 class="mt-2">Mon profil</h6>
-                                <p class="text-muted small">Informations personnelles</p>
+                                <h6 class="mt-2">My profile</h6>
+                                <p class="text-muted small">Personal information</p>
                             </div>
                         </a>
                     </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,13 +43,13 @@ class TestAuth:
         """Test que la page de connexion se charge correctement"""
         response = client.get('/auth/login')
         assert response.status_code == 200
-        assert b'Connexion' in response.data
+        assert b'Login' in response.data
 
     def test_register_page_loads(self, client):
         """Test que la page d'inscription se charge correctement"""
         response = client.get('/auth/register')
         assert response.status_code == 200
-        assert b'inscription' in response.data.lower()
+        assert b'sign up' in response.data.lower()
 
     def test_user_registration(self, client, app):
         """Test l'inscription d'un nouvel utilisateur"""
@@ -64,7 +64,7 @@ class TestAuth:
                 'password': 'testpassword123',
                 'password2': 'testpassword123',
                 'role_id': student_role.id,
-                'submit': 'S\'inscrire'
+                'submit': 'Sign up'
             })
             
             # Doit rediriger vers la page de connexion après inscription
@@ -81,7 +81,7 @@ class TestAuth:
         response = client.post('/auth/login', data={
             'email': 'invalid@example.com',
             'password': 'wrongpassword',
-            'submit': 'Se connecter'
+            'submit': 'Log in'
         })
         
         assert response.status_code == 200
@@ -105,7 +105,7 @@ class TestAuth:
         response = client.post('/auth/login', data={
             'email': 'test@example.com',
             'password': 'testpassword123',
-            'submit': 'Se connecter'
+            'submit': 'Log in'
         })
         
         # Doit rediriger vers la vérification MFA
@@ -134,7 +134,7 @@ class TestAuth:
             
         response = client.post('/auth/mfa-verify', data={
             'code': 'test_mfa_code',
-            'submit': 'Vérifier'
+            'submit': 'Verify'
         })
         
         # Doit rediriger après MFA réussi


### PR DESCRIPTION
## Summary
- translate form labels to English
- update templates for English text
- update admin, parent and student dashboards
- adjust tests for new English content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b87d77cc832981393e443b790d10