### PR TITLE
Améliore l'affichage de l'emploi du temps

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -217,3 +217,16 @@ footer {
         --dark-color: #f8f9fa;
     }
 }
+
+/* Schedule Calendar */
+#scheduleCalendar {
+    background: #fff;
+    border-radius: 10px;
+    padding: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.fc-toolbar-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+}

--- a/static/js/schedule.js
+++ b/static/js/schedule.js
@@ -1,0 +1,30 @@
+// Schedule calendar initialization using FullCalendar
+// Requires a div with id 'scheduleCalendar' and a data-events attribute
+
+document.addEventListener('DOMContentLoaded', function() {
+  var calendarEl = document.getElementById('scheduleCalendar');
+  if (!calendarEl) return;
+
+  var eventsData = [];
+  try {
+    eventsData = JSON.parse(calendarEl.dataset.events || '[]');
+  } catch (e) {
+    console.error('Invalid schedule event data', e);
+  }
+
+  var calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'timeGridWeek',
+    allDaySlot: false,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'timeGridWeek,timeGridDay'
+    },
+    height: 'auto',
+    slotMinTime: '07:00:00',
+    slotMaxTime: '19:00:00',
+    events: eventsData
+  });
+
+  calendar.render();
+});

--- a/templates/parent/child_schedule.html
+++ b/templates/parent/child_schedule.html
@@ -2,32 +2,29 @@
 
 {% block title %}Schedule - {{ child.user.first_name }}{% endblock %}
 
+{% block extra_css %}
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-calendar3 me-2"></i>Schedule for {{ child.user.first_name }} {{ child.user.last_name }}</h2>
 {% if schedules %}
-<div class="table-responsive">
-    <table class="table table-sm">
-        <thead>
-            <tr>
-                <th>Day</th>
-                <th>Start</th>
-                <th>End</th>
-                <th>Subject</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for s in schedules %}
-            <tr>
-                <td>{{ s.day_of_week }}</td>
-                <td>{{ s.start_time.strftime('%H:%M') }}</td>
-                <td>{{ s.end_time.strftime('%H:%M') }}</td>
-                <td>{{ s.course.name }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
+<div id="scheduleCalendar" data-events='[
+    {% for sched in schedules %}
+    {
+        "title": "{{ sched.course.name | e }} ({{ sched.classroom }})",
+        "daysOfWeek": [{{ {'Monday':1,'Tuesday':2,'Wednesday':3,'Thursday':4,'Friday':5,'Saturday':6,'Sunday':0}[sched.day_of_week] }}],
+        "startTime": "{{ sched.start_time.strftime('%H:%M') }}",
+        "endTime": "{{ sched.end_time.strftime('%H:%M') }}"
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+]'></div>
 {% else %}
 <p class="text-muted text-center">No schedule available.</p>
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+<script src="{{ url_for('static', filename='js/schedule.js') }}"></script>
 {% endblock %}

--- a/templates/student/schedule.html
+++ b/templates/student/schedule.html
@@ -2,34 +2,29 @@
 
 {% block title %}My Schedule{% endblock %}
 
+{% block extra_css %}
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-calendar3 me-2"></i>My Schedule</h2>
 {% if schedules %}
-<div class="table-responsive">
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>Day</th>
-                <th>Start</th>
-                <th>End</th>
-                <th>Subject</th>
-                <th>Classroom</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for sched in schedules %}
-            <tr>
-                <td>{{ sched.day_of_week }}</td>
-                <td>{{ sched.start_time.strftime('%H:%M') }}</td>
-                <td>{{ sched.end_time.strftime('%H:%M') }}</td>
-                <td>{{ sched.course.name }}</td>
-                <td>{{ sched.classroom }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
+<div id="scheduleCalendar" data-events='[
+    {% for sched in schedules %}
+    {
+        "title": "{{ sched.course.name | e }} ({{ sched.classroom }})",
+        "daysOfWeek": [{{ {'Monday':1,'Tuesday':2,'Wednesday':3,'Thursday':4,'Friday':5,'Saturday':6,'Sunday':0}[sched.day_of_week] }}],
+        "startTime": "{{ sched.start_time.strftime('%H:%M') }}",
+        "endTime": "{{ sched.end_time.strftime('%H:%M') }}"
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+]'></div>
 {% else %}
 <p class="text-muted">No schedule available.</p>
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+<script src="{{ url_for('static', filename='js/schedule.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add FullCalendar integration for schedule pages
- include new JS helper for calendar setup
- style the calendar to match the site theme

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e433e1dc83299cd25e36e89b8325