### PR TITLE
Fix schedule calendar display

### DIFF
--- a/routes/parent.py
+++ b/routes/parent.py
@@ -72,8 +72,23 @@ def child_schedule(student_id):
     schedules = Schedule.query.join(Course)\
                              .filter(Schedule.class_group == child.class_name)\
                              .order_by(Schedule.day_of_week, Schedule.start_time).all()
-    
-    return render_template('parent/child_schedule.html', child=child, schedules=schedules)
+
+    day_map = {
+        'Monday': 1, 'Tuesday': 2, 'Wednesday': 3,
+        'Thursday': 4, 'Friday': 5, 'Saturday': 6,
+        'Sunday': 0
+    }
+    events = [
+        {
+            'title': f"{s.course.name} ({s.classroom})",
+            'daysOfWeek': [day_map.get(s.day_of_week, 0)],
+            'startTime': s.start_time.strftime('%H:%M'),
+            'endTime': s.end_time.strftime('%H:%M')
+        }
+        for s in schedules
+    ]
+
+    return render_template('parent/child_schedule.html', child=child, events=events)
 
 @bp.route('/child/<int:student_id>/absences')
 @login_required

--- a/routes/student.py
+++ b/routes/student.py
@@ -56,13 +56,29 @@ def grades():
 @student_required
 def schedule():
     student = current_user.student_profile
-    
+
     # Get the schedule for the student's class
     schedules = Schedule.query.join(Course)\
                              .filter(Schedule.class_group == student.class_name)\
                              .order_by(Schedule.day_of_week, Schedule.start_time).all()
-    
-    return render_template('student/schedule.html', schedules=schedules)
+
+    # Convert schedule objects to a format usable by the calendar
+    day_map = {
+        'Monday': 1, 'Tuesday': 2, 'Wednesday': 3,
+        'Thursday': 4, 'Friday': 5, 'Saturday': 6,
+        'Sunday': 0
+    }
+    events = [
+        {
+            'title': f"{s.course.name} ({s.classroom})",
+            'daysOfWeek': [day_map.get(s.day_of_week, 0)],
+            'startTime': s.start_time.strftime('%H:%M'),
+            'endTime': s.end_time.strftime('%H:%M')
+        }
+        for s in schedules
+    ]
+
+    return render_template('student/schedule.html', events=events)
 
 @bp.route('/absences')
 @login_required

--- a/templates/parent/child_schedule.html
+++ b/templates/parent/child_schedule.html
@@ -8,17 +8,8 @@
 
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-calendar3 me-2"></i>Schedule for {{ child.user.first_name }} {{ child.user.last_name }}</h2>
-{% if schedules %}
-<div id="scheduleCalendar" data-events='[
-    {% for sched in schedules %}
-    {
-        "title": "{{ sched.course.name | e }} ({{ sched.classroom }})",
-        "daysOfWeek": [{{ {'Monday':1,'Tuesday':2,'Wednesday':3,'Thursday':4,'Friday':5,'Saturday':6,'Sunday':0}[sched.day_of_week] }}],
-        "startTime": "{{ sched.start_time.strftime('%H:%M') }}",
-        "endTime": "{{ sched.end_time.strftime('%H:%M') }}"
-    }{% if not loop.last %},{% endif %}
-    {% endfor %}
-]'></div>
+{% if events %}
+<div id="scheduleCalendar" data-events='{{ events | tojson | safe }}'></div>
 {% else %}
 <p class="text-muted text-center">No schedule available.</p>
 {% endif %}

--- a/templates/student/schedule.html
+++ b/templates/student/schedule.html
@@ -8,17 +8,8 @@
 
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-calendar3 me-2"></i>My Schedule</h2>
-{% if schedules %}
-<div id="scheduleCalendar" data-events='[
-    {% for sched in schedules %}
-    {
-        "title": "{{ sched.course.name | e }} ({{ sched.classroom }})",
-        "daysOfWeek": [{{ {'Monday':1,'Tuesday':2,'Wednesday':3,'Thursday':4,'Friday':5,'Saturday':6,'Sunday':0}[sched.day_of_week] }}],
-        "startTime": "{{ sched.start_time.strftime('%H:%M') }}",
-        "endTime": "{{ sched.end_time.strftime('%H:%M') }}"
-    }{% if not loop.last %},{% endif %}
-    {% endfor %}
-]'></div>
+{% if events %}
+<div id="scheduleCalendar" data-events='{{ events | tojson | safe }}'></div>
 {% else %}
 <p class="text-muted">No schedule available.</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- prepare schedule events in routes instead of jinja loops
- render schedule events as JSON in templates

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f41366b88329bd67af4248a32759