### PR TITLE
Improve grades UI

### DIFF
--- a/routes/parent.py
+++ b/routes/parent.py
@@ -57,8 +57,20 @@ def child_grades(student_id):
     grades = Grade.query.filter_by(student_id=student_id)\
                        .join(Course)\
                        .order_by(Grade.date_recorded.desc()).all()
-    
-    return render_template('parent/child_grades.html', child=child, grades=grades)
+
+    if grades:
+        values = [g.grade_value for g in grades]
+        average = round(sum(values) / len(values), 1)
+        best = round(max(values), 1)
+        high_count = len([v for v in values if v >= 16])
+        low_count = len([v for v in values if v <= 10])
+    else:
+        average = best = 0
+        high_count = low_count = 0
+
+    return render_template('parent/child_grades.html', child=child, grades=grades,
+                           average=average, best=best,
+                           high_count=high_count, low_count=low_count)
 
 @bp.route('/child/<int:student_id>/schedule')
 @login_required

--- a/routes/student.py
+++ b/routes/student.py
@@ -48,8 +48,21 @@ def grades():
     grades = Grade.query.filter_by(student_id=student.id)\
                        .join(Course)\
                        .order_by(Grade.date_recorded.desc()).all()
-    
-    return render_template('student/grades.html', grades=grades)
+
+    # Basic statistics for UI summary
+    if grades:
+        values = [g.grade_value for g in grades]
+        average = round(sum(values) / len(values), 1)
+        best = round(max(values), 1)
+        high_count = len([v for v in values if v >= 16])
+        low_count = len([v for v in values if v <= 10])
+    else:
+        average = best = 0
+        high_count = low_count = 0
+
+    return render_template('student/grades.html', grades=grades,
+                           average=average, best=best,
+                           high_count=high_count, low_count=low_count)
 
 @bp.route('/schedule')
 @login_required

--- a/routes/teacher.py
+++ b/routes/teacher.py
@@ -122,5 +122,17 @@ def grades():
                        .join(Course)\
                        .join(Student)\
                        .order_by(Grade.date_recorded.desc()).all()
-    
-    return render_template('teacher/grades.html', grades=grades)
+
+    if grades:
+        values = [g.grade_value for g in grades]
+        average = round(sum(values) / len(values), 1)
+        best = round(max(values), 1)
+        high_count = len([v for v in values if v >= 16])
+        low_count = len([v for v in values if v <= 10])
+    else:
+        average = best = 0
+        high_count = low_count = 0
+
+    return render_template('teacher/grades.html', grades=grades,
+                           average=average, best=best,
+                           high_count=high_count, low_count=low_count)

--- a/templates/parent/child_grades.html
+++ b/templates/parent/child_grades.html
@@ -5,8 +5,43 @@
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-clipboard-data me-2"></i>Grades for {{ child.user.first_name }} {{ child.user.last_name }}</h2>
 {% if grades %}
+<div class="row g-3 mb-4">
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Average</h6>
+                <h3 class="mb-0">{{ average }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Best</h6>
+                <h3 class="mb-0">{{ best }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≥16</h6>
+                <h3 class="mb-0">{{ high_count }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≤10</h6>
+                <h3 class="mb-0">{{ low_count }}</h3>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="table-responsive">
-    <table class="table table-sm">
+    <table class="table table-sm align-middle">
         <thead>
             <tr>
                 <th>Subject</th>
@@ -19,7 +54,15 @@
             {% for grade in grades %}
             <tr>
                 <td>{{ grade.course.name }}</td>
-                <td>{{ grade.grade_value }}</td>
+                {% set color = 'success' if grade.grade_value >= 16 else 'warning' if grade.grade_value >= 10 else 'danger' %}
+                <td>
+                    <div class="d-flex align-items-center" style="min-width:100px;">
+                        <strong class="me-2 text-{{ color }}">{{ "%.1f"|format(grade.grade_value) }}</strong>
+                        <div class="progress flex-grow-1" style="height:6px;">
+                            <div class="progress-bar bg-{{ color }}" role="progressbar" style="width: {{ (grade.grade_value / 20 * 100)|round(0,'floor') }}%"></div>
+                        </div>
+                    </div>
+                </td>
                 <td>{{ grade.grade_type }}</td>
                 <td>{{ grade.date_recorded.strftime('%d/%m/%Y') }}</td>
             </tr>

--- a/templates/student/grades.html
+++ b/templates/student/grades.html
@@ -5,8 +5,43 @@
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-clipboard-data me-2"></i>My Grades</h2>
 {% if grades %}
+<div class="row g-3 mb-4">
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Average</h6>
+                <h3 class="mb-0">{{ average }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Best</h6>
+                <h3 class="mb-0">{{ best }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≥16</h6>
+                <h3 class="mb-0">{{ high_count }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≤10</h6>
+                <h3 class="mb-0">{{ low_count }}</h3>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="table-responsive">
-    <table class="table table-striped">
+    <table class="table table-striped align-middle">
         <thead>
             <tr>
                 <th>Subject</th>
@@ -19,10 +54,14 @@
             {% for grade in grades %}
             <tr>
                 <td>{{ grade.course.name }}</td>
+                {% set color = 'success' if grade.grade_value >= 16 else 'warning' if grade.grade_value >= 10 else 'danger' %}
                 <td>
-                    <span class="badge bg-{{ 'success' if grade.grade_value >= 10 else 'danger' }}">
-                        {{ "%.1f"|format(grade.grade_value) }}/20
-                    </span>
+                    <div class="d-flex align-items-center" style="min-width:100px;">
+                        <strong class="me-2 text-{{ color }}">{{ "%.1f"|format(grade.grade_value) }}</strong>
+                        <div class="progress flex-grow-1" style="height:6px;">
+                            <div class="progress-bar bg-{{ color }}" role="progressbar" style="width: {{ (grade.grade_value / 20 * 100)|round(0,'floor') }}%"></div>
+                        </div>
+                    </div>
                 </td>
                 <td>{{ grade.grade_type }}</td>
                 <td>{{ grade.date_recorded.strftime('%d/%m/%Y') }}</td>

--- a/templates/teacher/grades.html
+++ b/templates/teacher/grades.html
@@ -5,8 +5,43 @@
 {% block content %}
 <h2 class="mb-4"><i class="bi bi-clipboard-data me-2"></i>Entered Grades</h2>
 {% if grades %}
+<div class="row g-3 mb-4">
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Average</h6>
+                <h3 class="mb-0">{{ average }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">Best</h6>
+                <h3 class="mb-0">{{ best }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≥16</h6>
+                <h3 class="mb-0">{{ high_count }}</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="card shadow-sm text-center">
+            <div class="card-body">
+                <h6 class="text-muted">≤10</h6>
+                <h3 class="mb-0">{{ low_count }}</h3>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="table-responsive">
-    <table class="table table-sm">
+    <table class="table table-sm align-middle">
         <thead>
             <tr>
                 <th>Student</th>
@@ -21,7 +56,15 @@
             <tr>
                 <td>{{ grade.student.user.first_name }} {{ grade.student.user.last_name }}</td>
                 <td>{{ grade.course.name }}</td>
-                <td>{{ grade.grade_value }}</td>
+                {% set color = 'success' if grade.grade_value >= 16 else 'warning' if grade.grade_value >= 10 else 'danger' %}
+                <td>
+                    <div class="d-flex align-items-center" style="min-width:100px;">
+                        <strong class="me-2 text-{{ color }}">{{ "%.1f"|format(grade.grade_value) }}</strong>
+                        <div class="progress flex-grow-1" style="height:6px;">
+                            <div class="progress-bar bg-{{ color }}" role="progressbar" style="width: {{ (grade.grade_value / 20 * 100)|round(0,'floor') }}%"></div>
+                        </div>
+                    </div>
+                </td>
                 <td>{{ grade.grade_type }}</td>
                 <td>{{ grade.date_recorded.strftime('%d/%m/%Y') }}</td>
             </tr>


### PR DESCRIPTION
## Summary
- compute grade statistics for teachers, parents and students
- show new summary cards for grade pages
- add progress bars in grade tables for a cleaner look

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895bb097988329b64eb3ebf53f5ac7