### PR TITLE
Improve profile display and model fields

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,89 +1,144 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, BooleanField, SubmitField, SelectField, TextAreaField, FloatField, DateField, IntegerField
-from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange, Optional
+from wtforms import (
+    StringField,
+    PasswordField,
+    BooleanField,
+    SubmitField,
+    SelectField,
+    TextAreaField,
+    FloatField,
+    DateField,
+    IntegerField,
+)
+from wtforms.validators import (
+    DataRequired,
+    Email,
+    EqualTo,
+    Length,
+    NumberRange,
+    Optional,
+)
 from models import User, Role, Student, Teacher
 
+
 class LoginForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired(), Email()])
-    password = PasswordField('Password', validators=[DataRequired()])
-    remember_me = BooleanField('Remember me')
-    submit = SubmitField('Log in')
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    password = PasswordField("Password", validators=[DataRequired()])
+    remember_me = BooleanField("Remember me")
+    submit = SubmitField("Log in")
+
 
 class MFAForm(FlaskForm):
     # Allow codes up to 16 characters for tests and future extensions
-    code = StringField('Verification code', validators=[DataRequired(), Length(min=6, max=16)])
-    remember_me = BooleanField('Remember me')
-    submit = SubmitField('Verify')
+    code = StringField(
+        "Verification code", validators=[DataRequired(), Length(min=6, max=16)]
+    )
+    remember_me = BooleanField("Remember me")
+    submit = SubmitField("Verify")
+
 
 class RegisterForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired(), Email()])
-    first_name = StringField('First name', validators=[DataRequired(), Length(min=2, max=50)])
-    last_name = StringField('Last name', validators=[DataRequired(), Length(min=2, max=50)])
-    phone = StringField('Phone', validators=[Optional(), Length(max=20)])
-    password = PasswordField('Password', validators=[DataRequired(), Length(min=8)])
-    password2 = PasswordField('Confirm password',
-                             validators=[DataRequired(), EqualTo('password')])
-    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
-    submit = SubmitField('Sign up')
-    
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    first_name = StringField(
+        "First name", validators=[DataRequired(), Length(min=2, max=50)]
+    )
+    last_name = StringField(
+        "Last name", validators=[DataRequired(), Length(min=2, max=50)]
+    )
+    phone = StringField("Phone", validators=[Optional(), Length(max=20)])
+    address = StringField("Address", validators=[Optional(), Length(max=200)])
+    birthdate = DateField("Birthdate", validators=[Optional()])
+    password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
+    password2 = PasswordField(
+        "Confirm password", validators=[DataRequired(), EqualTo("password")]
+    )
+    role_id = SelectField("Role", coerce=int, validators=[DataRequired()])
+    submit = SubmitField("Sign up")
+
     def __init__(self, *args, **kwargs):
         super(RegisterForm, self).__init__(*args, **kwargs)
         self.role_id.choices = [(r.id, r.name) for r in Role.query.all()]
-    
+
     def validate_email(self, email):
         user = User.query.filter_by(email=email.data).first()
         if user is not None:
-            raise ValidationError('This email address is already in use.')
+            raise ValidationError("This email address is already in use.")
+
 
 class UserForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired(), Email()])
-    first_name = StringField('First name', validators=[DataRequired(), Length(min=2, max=50)])
-    last_name = StringField('Last name', validators=[DataRequired(), Length(min=2, max=50)])
-    phone = StringField('Phone', validators=[Optional(), Length(max=20)])
-    password = PasswordField('Password', validators=[Optional(), Length(min=8)])
-    role_id = SelectField('Role', coerce=int, validators=[DataRequired()])
-    is_active = BooleanField('Active account', default=True)
-    submit = SubmitField('Save')
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    first_name = StringField(
+        "First name", validators=[DataRequired(), Length(min=2, max=50)]
+    )
+    last_name = StringField(
+        "Last name", validators=[DataRequired(), Length(min=2, max=50)]
+    )
+    phone = StringField("Phone", validators=[Optional(), Length(max=20)])
+    address = StringField("Address", validators=[Optional(), Length(max=200)])
+    birthdate = DateField("Birthdate", validators=[Optional()])
+    password = PasswordField("Password", validators=[Optional(), Length(min=8)])
+    role_id = SelectField("Role", coerce=int, validators=[DataRequired()])
+    is_active = BooleanField("Active account", default=True)
+    submit = SubmitField("Save")
+
 
 class GradeForm(FlaskForm):
-    student_id = SelectField('Student', coerce=int, validators=[DataRequired()])
-    course_id = SelectField('Course', coerce=int, validators=[DataRequired()])
-    grade_value = FloatField('Grade', validators=[DataRequired(), NumberRange(min=0, max=20)])
-    grade_type = SelectField('Type', choices=[
-        ('Test', 'Test'),
-        ('Exam', 'Exam'),
-        ('Homework', 'Homework'),
-        ('Participation', 'Participation')
-    ], validators=[DataRequired()])
-    comments = TextAreaField('Comments', validators=[Optional()])
-    submit = SubmitField('Add grade')
-    
+    student_id = SelectField("Student", coerce=int, validators=[DataRequired()])
+    course_id = SelectField("Course", coerce=int, validators=[DataRequired()])
+    grade_value = FloatField(
+        "Grade", validators=[DataRequired(), NumberRange(min=0, max=20)]
+    )
+    grade_type = SelectField(
+        "Type",
+        choices=[
+            ("Test", "Test"),
+            ("Exam", "Exam"),
+            ("Homework", "Homework"),
+            ("Participation", "Participation"),
+        ],
+        validators=[DataRequired()],
+    )
+    comments = TextAreaField("Comments", validators=[Optional()])
+    submit = SubmitField("Add grade")
+
     def __init__(self, *args, **kwargs):
         super(GradeForm, self).__init__(*args, **kwargs)
-        self.student_id.choices = [(s.id, f"{s.user.first_name} {s.user.last_name}") 
-                                  for s in Student.query.join(User)]
+        self.student_id.choices = [
+            (s.id, f"{s.user.first_name} {s.user.last_name}")
+            for s in Student.query.join(User)
+        ]
+
 
 class AbsenceForm(FlaskForm):
-    student_id = SelectField('Student', coerce=int, validators=[DataRequired()])
-    date = DateField('Date', validators=[DataRequired()])
-    period = SelectField('Period', choices=[
-        ('Morning', 'Morning'),
-        ('Afternoon', 'Afternoon'),
-        ('Day', 'Full day')
-    ], validators=[DataRequired()])
-    is_justified = BooleanField('Justified absence', default=False)
-    reason = StringField('Reason', validators=[Optional(), Length(max=200)])
+    student_id = SelectField("Student", coerce=int, validators=[DataRequired()])
+    date = DateField("Date", validators=[DataRequired()])
+    period = SelectField(
+        "Period",
+        choices=[
+            ("Morning", "Morning"),
+            ("Afternoon", "Afternoon"),
+            ("Day", "Full day"),
+        ],
+        validators=[DataRequired()],
+    )
+    is_justified = BooleanField("Justified absence", default=False)
+    reason = StringField("Reason", validators=[Optional(), Length(max=200)])
     submit = SubmitField("Save absence")
-    
+
     def __init__(self, *args, **kwargs):
         super(AbsenceForm, self).__init__(*args, **kwargs)
-        self.student_id.choices = [(s.id, f"{s.user.first_name} {s.user.last_name}") 
-                                  for s in Student.query.join(User)]
+        self.student_id.choices = [
+            (s.id, f"{s.user.first_name} {s.user.last_name}")
+            for s in Student.query.join(User)
+        ]
+
 
 class CourseForm(FlaskForm):
-    name = StringField('Course name', validators=[DataRequired(), Length(max=100)])
-    code = StringField('Code', validators=[DataRequired(), Length(max=20)])
-    description = TextAreaField('Description', validators=[Optional()])
-    credits = IntegerField('Credits', validators=[DataRequired(), NumberRange(min=1, max=10)])
-    teacher_id = SelectField('Teacher', coerce=int, validators=[DataRequired()])
-    submit = SubmitField('Save')
+    name = StringField("Course name", validators=[DataRequired(), Length(max=100)])
+    code = StringField("Code", validators=[DataRequired(), Length(max=20)])
+    description = TextAreaField("Description", validators=[Optional()])
+    credits = IntegerField(
+        "Credits", validators=[DataRequired(), NumberRange(min=1, max=10)]
+    )
+    teacher_id = SelectField("Teacher", coerce=int, validators=[DataRequired()])
+    submit = SubmitField("Save")

--- a/models.py
+++ b/models.py
@@ -8,49 +8,53 @@ import secrets
 # outside the session in tests and background tasks
 db = SQLAlchemy(session_options={"expire_on_commit": False})
 
+
 class Role(db.Model):
-    __tablename__ = 'roles'
-    
+    __tablename__ = "roles"
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(50), unique=True, nullable=False)
     description = db.Column(db.String(200))
-    
-    users = db.relationship('User', backref='role', lazy=True)
+
+    users = db.relationship("User", backref="role", lazy=True)
+
 
 class User(UserMixin, db.Model):
-    __tablename__ = 'users'
-    
+    __tablename__ = "users"
+
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
-    password_hash = db.Column(db.String(255), nullable=False, default='')
+    password_hash = db.Column(db.String(255), nullable=False, default="")
     first_name = db.Column(db.String(50), nullable=False)
     last_name = db.Column(db.String(50), nullable=False)
     phone = db.Column(db.String(20))
+    address = db.Column(db.String(200))
+    birthdate = db.Column(db.Date)
     is_active = db.Column(db.Boolean, default=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     last_login = db.Column(db.DateTime)
-    
+
     # MFA
     mfa_secret = db.Column(db.String(32))
     mfa_verified = db.Column(db.Boolean, default=False)
-    
+
     # Relations
-    role_id = db.Column(db.Integer, db.ForeignKey('roles.id'), nullable=False)
-    
+    role_id = db.Column(db.Integer, db.ForeignKey("roles.id"), nullable=False)
+
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
-    
+
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
-    
+
     def generate_mfa_code(self):
         self.mfa_secret = secrets.token_hex(6)
         db.session.commit()
         return self.mfa_secret
-    
+
     def verify_mfa_code(self, code):
         return self.mfa_secret == code
-    
+
     def has_role(self, role_name):
         """Return True if the user has the given role."""
         if self.role is not None:
@@ -58,14 +62,23 @@ class User(UserMixin, db.Model):
         # When the relationship is not loaded, fall back to role_id comparison
         role = Role.query.get(self.role_id) if self.role_id else None
         return role.name == role_name if role else False
-    
+
     def can(self, permission):
         """Return True if the user's role grants the given permission."""
         permissions = {
-            'student': ['view_grades', 'view_schedule', 'view_profile'],
-            'parent': ['view_child_grades', 'view_child_schedule', 'view_child_absences'],
-            'teacher': ['add_grades', 'mark_absences', 'view_classes', 'send_messages'],
-            'admin': ['manage_users', 'manage_courses', 'manage_schedule', 'view_dashboard']
+            "student": ["view_grades", "view_schedule", "view_profile"],
+            "parent": [
+                "view_child_grades",
+                "view_child_schedule",
+                "view_child_absences",
+            ],
+            "teacher": ["add_grades", "mark_absences", "view_classes", "send_messages"],
+            "admin": [
+                "manage_users",
+                "manage_courses",
+                "manage_schedule",
+                "view_dashboard",
+            ],
         }
         if self.role is None and self.role_id:
             role = Role.query.get(self.role_id)
@@ -74,123 +87,137 @@ class User(UserMixin, db.Model):
             role_name = self.role.name if self.role else None
         return permission in permissions.get(role_name, [])
 
+
 class Student(db.Model):
-    __tablename__ = 'students'
-    
+    __tablename__ = "students"
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     student_number = db.Column(db.String(20), unique=True, nullable=False)
     class_name = db.Column(db.String(50), nullable=False)
     enrollment_date = db.Column(db.Date, nullable=False)
-    
-    user = db.relationship('User', backref=db.backref('student_profile', uselist=False))
-    grades = db.relationship('Grade', backref='student', lazy=True)
-    absences = db.relationship('Absence', backref='student', lazy=True)
+
+    user = db.relationship("User", backref=db.backref("student_profile", uselist=False))
+    grades = db.relationship("Grade", backref="student", lazy=True)
+    absences = db.relationship("Absence", backref="student", lazy=True)
+
 
 class Parent(db.Model):
-    __tablename__ = 'parents'
-    
+    __tablename__ = "parents"
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
-    
-    user = db.relationship('User', backref=db.backref('parent_profile', uselist=False))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    user = db.relationship("User", backref=db.backref("parent_profile", uselist=False))
+
 
 class ParentStudent(db.Model):
-    __tablename__ = 'parent_student'
-    
+    __tablename__ = "parent_student"
+
     id = db.Column(db.Integer, primary_key=True)
-    parent_id = db.Column(db.Integer, db.ForeignKey('parents.id'), nullable=False)
-    student_id = db.Column(db.Integer, db.ForeignKey('students.id'), nullable=False)
-    relationship_type = db.Column(db.String(50), nullable=False)  # father, mother, guardian
-    
-    parent = db.relationship('Parent', backref='children')
-    student = db.relationship('Student', backref='parents')
+    parent_id = db.Column(db.Integer, db.ForeignKey("parents.id"), nullable=False)
+    student_id = db.Column(db.Integer, db.ForeignKey("students.id"), nullable=False)
+    relationship_type = db.Column(
+        db.String(50), nullable=False
+    )  # father, mother, guardian
+
+    parent = db.relationship("Parent", backref="children")
+    student = db.relationship("Student", backref="parents")
+
 
 class Teacher(db.Model):
-    __tablename__ = 'teachers'
-    
+    __tablename__ = "teachers"
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     employee_number = db.Column(db.String(20), unique=True, nullable=False)
     department = db.Column(db.String(100), nullable=False)
     hire_date = db.Column(db.Date, nullable=False)
-    
-    user = db.relationship('User', backref=db.backref('teacher_profile', uselist=False))
-    courses = db.relationship('Course', backref='teacher', lazy=True)
+
+    user = db.relationship("User", backref=db.backref("teacher_profile", uselist=False))
+    courses = db.relationship("Course", backref="teacher", lazy=True)
+
 
 class Administrator(db.Model):
-    __tablename__ = 'administrators'
-    
+    __tablename__ = "administrators"
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     employee_number = db.Column(db.String(20), unique=True, nullable=False)
     position = db.Column(db.String(100), nullable=False)
-    
-    user = db.relationship('User', backref=db.backref('admin_profile', uselist=False))
+
+    user = db.relationship("User", backref=db.backref("admin_profile", uselist=False))
+
 
 class Course(db.Model):
-    __tablename__ = 'courses'
-    
+    __tablename__ = "courses"
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     code = db.Column(db.String(20), unique=True, nullable=False)
     description = db.Column(db.Text)
     credits = db.Column(db.Integer, default=1)
-    teacher_id = db.Column(db.Integer, db.ForeignKey('teachers.id'), nullable=False)
-    
-    grades = db.relationship('Grade', backref='course', lazy=True)
-    schedules = db.relationship('Schedule', backref='course', lazy=True)
+    teacher_id = db.Column(db.Integer, db.ForeignKey("teachers.id"), nullable=False)
+
+    grades = db.relationship("Grade", backref="course", lazy=True)
+    schedules = db.relationship("Schedule", backref="course", lazy=True)
+
 
 class Grade(db.Model):
-    __tablename__ = 'grades'
-    
+    __tablename__ = "grades"
+
     id = db.Column(db.Integer, primary_key=True)
-    student_id = db.Column(db.Integer, db.ForeignKey('students.id'), nullable=False)
-    course_id = db.Column(db.Integer, db.ForeignKey('courses.id'), nullable=False)
+    student_id = db.Column(db.Integer, db.ForeignKey("students.id"), nullable=False)
+    course_id = db.Column(db.Integer, db.ForeignKey("courses.id"), nullable=False)
     grade_value = db.Column(db.Float, nullable=False)
     grade_type = db.Column(db.String(50), nullable=False)  # Test, Exam, Homework
     date_recorded = db.Column(db.DateTime, default=datetime.utcnow)
-    teacher_id = db.Column(db.Integer, db.ForeignKey('teachers.id'), nullable=False)
+    teacher_id = db.Column(db.Integer, db.ForeignKey("teachers.id"), nullable=False)
     comments = db.Column(db.Text)
-    
-    teacher = db.relationship('Teacher', backref='grades_given')
+
+    teacher = db.relationship("Teacher", backref="grades_given")
+
 
 class Absence(db.Model):
-    __tablename__ = 'absences'
-    
+    __tablename__ = "absences"
+
     id = db.Column(db.Integer, primary_key=True)
-    student_id = db.Column(db.Integer, db.ForeignKey('students.id'), nullable=False)
+    student_id = db.Column(db.Integer, db.ForeignKey("students.id"), nullable=False)
     date = db.Column(db.Date, nullable=False)
     period = db.Column(db.String(50), nullable=False)  # Morning, Afternoon, Full day
     is_justified = db.Column(db.Boolean, default=False)
     reason = db.Column(db.String(200))
-    teacher_id = db.Column(db.Integer, db.ForeignKey('teachers.id'), nullable=False)
+    teacher_id = db.Column(db.Integer, db.ForeignKey("teachers.id"), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    
-    teacher = db.relationship('Teacher', backref='absences_marked')
+
+    teacher = db.relationship("Teacher", backref="absences_marked")
+
 
 class Schedule(db.Model):
-    __tablename__ = 'schedules'
-    
+    __tablename__ = "schedules"
+
     id = db.Column(db.Integer, primary_key=True)
-    course_id = db.Column(db.Integer, db.ForeignKey('courses.id'), nullable=False)
+    course_id = db.Column(db.Integer, db.ForeignKey("courses.id"), nullable=False)
     day_of_week = db.Column(db.String(20), nullable=False)  # Monday, Tuesday, etc.
     start_time = db.Column(db.Time, nullable=False)
     end_time = db.Column(db.Time, nullable=False)
     classroom = db.Column(db.String(50), nullable=False)
     class_group = db.Column(db.String(50), nullable=False)
 
+
 class AuthLog(db.Model):
-    __tablename__ = 'auth_logs'
-    
+    __tablename__ = "auth_logs"
+
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
     email = db.Column(db.String(120), nullable=False)
-    action = db.Column(db.String(50), nullable=False)  # login_attempt, login_success, logout
+    action = db.Column(
+        db.String(50), nullable=False
+    )  # login_attempt, login_success, logout
     ip_address = db.Column(db.String(45))
     user_agent = db.Column(db.String(500))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     success = db.Column(db.Boolean, nullable=False)
     details = db.Column(db.Text)
-    
-    user = db.relationship('User', backref='auth_logs')
+
+    user = db.relationship("User", backref="auth_logs")

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,35 +1,77 @@
 from flask import Blueprint, render_template, redirect, url_for
 from flask_login import login_required, current_user
+from models import (
+    User,
+    Student,
+    Parent,
+    ParentStudent,
+    Teacher,
+    Administrator,
+    Course,
+    Grade,
+)
 
-bp = Blueprint('main', __name__)
+bp = Blueprint("main", __name__)
 
-@bp.route('/')
+
+@bp.route("/")
 def index():
     if current_user.is_authenticated:
-        return redirect(url_for('main.dashboard'))
-    return render_template('main/index.html')
+        return redirect(url_for("main.dashboard"))
+    return render_template("main/index.html")
 
-@bp.route('/dashboard')
+
+@bp.route("/dashboard")
 @login_required
 def dashboard():
     if not current_user.mfa_verified:
-        return redirect(url_for('auth.mfa_verify'))
-    
+        return redirect(url_for("auth.mfa_verify"))
+
     # Redirection vers le dashboard approprié selon le rôle
     role = current_user.role.name
-    
-    if role == 'student':
-        return redirect(url_for('student.dashboard'))
-    elif role == 'parent':
-        return redirect(url_for('parent.dashboard'))
-    elif role == 'teacher':
-        return redirect(url_for('teacher.dashboard'))
-    elif role == 'admin':
-        return redirect(url_for('admin.dashboard'))
-    else:
-        return render_template('main/dashboard.html')
 
-@bp.route('/profile')
+    if role == "student":
+        return redirect(url_for("student.dashboard"))
+    elif role == "parent":
+        return redirect(url_for("parent.dashboard"))
+    elif role == "teacher":
+        return redirect(url_for("teacher.dashboard"))
+    elif role == "admin":
+        return redirect(url_for("admin.dashboard"))
+    else:
+        return render_template("main/dashboard.html")
+
+
+@bp.route("/profile")
 @login_required
 def profile():
-    return render_template('main/profile.html')
+    role = current_user.role.name
+    context = {"role": role}
+
+    if role == "student":
+        context["student"] = current_user.student_profile
+    elif role == "parent":
+        parent = current_user.parent_profile
+        children = (
+            Student.query.join(ParentStudent)
+            .filter(ParentStudent.parent_id == parent.id)
+            .all()
+        )
+        context["children"] = children
+    elif role == "teacher":
+        teacher = current_user.teacher_profile
+        courses = Course.query.filter_by(teacher_id=teacher.id).all()
+        context["teacher"] = teacher
+        context["courses"] = courses
+    elif role == "admin":
+        stats = {
+            "total_users": User.query.count(),
+            "total_students": Student.query.count(),
+            "total_teachers": Teacher.query.count(),
+            "total_parents": Parent.query.count(),
+            "total_courses": Course.query.count(),
+            "total_grades": Grade.query.count(),
+        }
+        context["stats"] = stats
+
+    return render_template("main/profile.html", **context)

--- a/templates/main/profile.html
+++ b/templates/main/profile.html
@@ -3,21 +3,88 @@
 {% block title %}My Profile{% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card shadow-sm">
-            <div class="card-header bg-primary text-white">
-                <h5 class="mb-0"><i class="bi bi-person me-2"></i>My Profile</h5>
-            </div>
-            <div class="card-body">
-                <ul class="list-group list-group-flush">
-                    <li class="list-group-item"><strong>First name:</strong> {{ current_user.first_name }}</li>
-                    <li class="list-group-item"><strong>Last name:</strong> {{ current_user.last_name }}</li>
-                    <li class="list-group-item"><strong>Email:</strong> {{ current_user.email }}</li>
-                    <li class="list-group-item"><strong>Role:</strong> {{ current_user.role.name }}</li>
+<div class="row">
+    <div class="col-lg-4 mb-4">
+        <div class="card h-100 shadow-sm">
+            <div class="bg-primary" style="height:120px;"></div>
+            <div class="card-body text-center">
+                <img src="https://via.placeholder.com/120" class="rounded-circle img-thumbnail" style="margin-top:-70px;" alt="avatar">
+                <h4 class="mt-2">{{ current_user.first_name }} {{ current_user.last_name }}</h4>
+                <p class="text-muted">{{ current_user.email }}</p>
+                <span class="badge bg-secondary">{{ role|capitalize }}</span>
+                <hr>
+                <ul class="list-unstyled text-start">
+                    <li><strong>Phone:</strong> {{ current_user.phone or 'N/A' }}</li>
+                    <li><strong>Birthdate:</strong> {{ current_user.birthdate.strftime('%d/%m/%Y') if current_user.birthdate else 'N/A' }}</li>
+                    <li><strong>Address:</strong> {{ current_user.address or 'N/A' }}</li>
                 </ul>
             </div>
         </div>
+    </div>
+    <div class="col-lg-8">
+        {% if role == 'student' %}
+        <div class="card mb-4">
+            <div class="card-header">School Information</div>
+            <div class="card-body">
+                <p><strong>Class:</strong> {{ student.class_name }}</p>
+                <p><strong>Student number:</strong> {{ student.student_number }}</p>
+                <p><strong>Enrollment date:</strong> {{ student.enrollment_date.strftime('%d/%m/%Y') }}</p>
+            </div>
+        </div>
+        {% elif role == 'parent' %}
+        <div class="card mb-4">
+            <div class="card-header">My Children</div>
+            <ul class="list-group list-group-flush">
+                {% for child in children %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    {{ child.user.first_name }} {{ child.user.last_name }} - {{ child.class_name }}
+                    <a href="{{ url_for('parent.child_grades', student_id=child.id) }}" class="btn btn-sm btn-outline-primary">View</a>
+                </li>
+                {% else %}
+                <li class="list-group-item">No child linked.</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% elif role == 'teacher' %}
+        <div class="card mb-4">
+            <div class="card-header">Teacher Info</div>
+            <div class="card-body">
+                <p><strong>Department:</strong> {{ teacher.department }}</p>
+                <p><strong>Employee #:</strong> {{ teacher.employee_number }}</p>
+                <p><strong>Hire date:</strong> {{ teacher.hire_date.strftime('%d/%m/%Y') }}</p>
+            </div>
+        </div>
+        <div class="card mb-4">
+            <div class="card-header">Courses</div>
+            <ul class="list-group list-group-flush">
+                {% for course in courses %}
+                <li class="list-group-item">{{ course.name }}</li>
+                {% else %}
+                <li class="list-group-item">No course assigned.</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% elif role == 'admin' %}
+        <div class="card mb-4">
+            <div class="card-header">Statistics</div>
+            <div class="card-body">
+                <div class="row text-center">
+                    <div class="col-sm-4">
+                        <h6>Users</h6>
+                        <p class="fs-4">{{ stats.total_users }}</p>
+                    </div>
+                    <div class="col-sm-4">
+                        <h6>Students</h6>
+                        <p class="fs-4">{{ stats.total_students }}</p>
+                    </div>
+                    <div class="col-sm-4">
+                        <h6>Teachers</h6>
+                        <p class="fs-4">{{ stats.total_teachers }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -1,4 +1,17 @@
-from models import db, Role, User, Student, Parent, Teacher, Administrator, Course, Grade, Absence, Schedule, ParentStudent
+from models import (
+    db,
+    Role,
+    User,
+    Student,
+    Parent,
+    Teacher,
+    Administrator,
+    Course,
+    Grade,
+    Absence,
+    Schedule,
+    ParentStudent,
+)
 from datetime import date, time, datetime, timedelta
 import random
 
@@ -8,51 +21,61 @@ def create_sample_data():
 
     # Roles
     roles = {
-        'student': 'Student',
-        'parent': 'Parent',
-        'teacher': 'Teacher',
-        'admin': 'Administrator'
+        "student": "Student",
+        "parent": "Parent",
+        "teacher": "Teacher",
+        "admin": "Administrator",
     }
     for rname, desc in roles.items():
         if not Role.query.filter_by(name=rname).first():
             db.session.add(Role(name=rname, description=desc))
     db.session.commit()
 
-    student_role = Role.query.filter_by(name='student').first()
-    parent_role = Role.query.filter_by(name='parent').first()
-    teacher_role = Role.query.filter_by(name='teacher').first()
-    admin_role = Role.query.filter_by(name='admin').first()
+    student_role = Role.query.filter_by(name="student").first()
+    parent_role = Role.query.filter_by(name="parent").first()
+    teacher_role = Role.query.filter_by(name="teacher").first()
+    admin_role = Role.query.filter_by(name="admin").first()
 
     # Predefined accounts for testing
-    if not User.query.filter_by(email='ulbis047@gmail.com').first():
-        user = User(email='ulbis047@gmail.com',
-                    first_name='Test',
-                    last_name='Admin',
-                    role_id=admin_role.id,
-                    is_active=True)
-        user.set_password('admin123')
+    if not User.query.filter_by(email="ulbis047@gmail.com").first():
+        user = User(
+            email="ulbis047@gmail.com",
+            first_name="Test",
+            last_name="Admin",
+            role_id=admin_role.id,
+            is_active=True,
+            phone="0102030405",
+            address="1 Admin Way",
+            birthdate=date(1980, 1, 1),
+        )
+        user.set_password("admin123")
         db.session.add(user)
         db.session.commit()
-        admin_profile = Administrator(user_id=user.id,
-                                      employee_number='ADM900',
-                                      position='Administrator')
+        admin_profile = Administrator(
+            user_id=user.id, employee_number="ADM900", position="Administrator"
+        )
         db.session.add(admin_profile)
         db.session.commit()
     # Administrators
     for i in range(1, 4):
         email = f"admin{i}@school.fr"
         if not User.query.filter_by(email=email).first():
-            user = User(email=email,
-                        first_name=f"Admin{i}",
-                        last_name="School",
-                        role_id=admin_role.id,
-                        is_active=True)
-            user.set_password('admin123')
+            user = User(
+                email=email,
+                first_name=f"Admin{i}",
+                last_name="School",
+                role_id=admin_role.id,
+                is_active=True,
+                phone="0102030405",
+                address="1 Admin Way",
+                birthdate=date(1980, 1, 1),
+            )
+            user.set_password("admin123")
             db.session.add(user)
             db.session.commit()
-            admin = Administrator(user_id=user.id,
-                                  employee_number=f"ADM{i:03d}",
-                                  position="Administrator")
+            admin = Administrator(
+                user_id=user.id, employee_number=f"ADM{i:03d}", position="Administrator"
+            )
             db.session.add(admin)
     db.session.commit()
 
@@ -61,134 +84,216 @@ def create_sample_data():
     for i in range(1, 31):
         email = f"teacher{i}@school.fr"
         if not User.query.filter_by(email=email).first():
-            user = User(email=email,
-                        first_name=f"Teacher{i}",
-                        last_name="Demo",
-                        role_id=teacher_role.id,
-                        is_active=True)
-            user.set_password('teacher123')
+            user = User(
+                email=email,
+                first_name=f"Teacher{i}",
+                last_name="Demo",
+                role_id=teacher_role.id,
+                is_active=True,
+                phone="0102030405",
+                address="1 Teacher St",
+                birthdate=date(1985, 1, 1),
+            )
+            user.set_password("teacher123")
             db.session.add(user)
             db.session.commit()
-            teacher = Teacher(user_id=user.id,
-                              employee_number=f"TCH{i:03d}",
-                              department="General",
-                              hire_date=date.today())
+            teacher = Teacher(
+                user_id=user.id,
+                employee_number=f"TCH{i:03d}",
+                department="General",
+                hire_date=date.today(),
+            )
             db.session.add(teacher)
             teachers.append(teacher)
         else:
-            teachers.append(Teacher.query.join(User).filter(User.email==email).first())
+            teachers.append(
+                Teacher.query.join(User).filter(User.email == email).first()
+            )
     db.session.commit()
 
     # Specific teacher for testing
-    if not User.query.filter_by(email='gbtexfares@gmail.com').first():
-        user = User(email='gbtexfares@gmail.com',
-                    first_name='Test',
-                    last_name='Teacher',
-                    role_id=teacher_role.id,
-                    is_active=True)
-        user.set_password('teacher123')
+    if not User.query.filter_by(email="gbtexfares@gmail.com").first():
+        user = User(
+            email="gbtexfares@gmail.com",
+            first_name="Test",
+            last_name="Teacher",
+            role_id=teacher_role.id,
+            is_active=True,
+            phone="0102030405",
+            address="1 Teacher St",
+            birthdate=date(1985, 1, 1),
+        )
+        user.set_password("teacher123")
         db.session.add(user)
         db.session.commit()
-        teacher_profile = Teacher(user_id=user.id,
-                                  employee_number='TCH900',
-                                  department='General',
-                                  hire_date=date.today())
+        teacher_profile = Teacher(
+            user_id=user.id,
+            employee_number="TCH900",
+            department="General",
+            hire_date=date.today(),
+        )
         db.session.add(teacher_profile)
         teachers.append(teacher_profile)
         db.session.commit()
     else:
-        teachers.append(Teacher.query.join(User).filter(User.email=='gbtexfares@gmail.com').first())
+        teachers.append(
+            Teacher.query.join(User)
+            .filter(User.email == "gbtexfares@gmail.com")
+            .first()
+        )
     # Students
-    class_groups = ['6A','6B','6C','5A','5B','5C','4A','4B','4C','3A','3B','3C']
+    class_groups = [
+        "6A",
+        "6B",
+        "6C",
+        "5A",
+        "5B",
+        "5C",
+        "4A",
+        "4B",
+        "4C",
+        "3A",
+        "3B",
+        "3C",
+    ]
     students = []
     for i in range(1, 101):
         email = f"student{i}@school.fr"
         if not User.query.filter_by(email=email).first():
-            user = User(email=email,
-                        first_name=f"Student{i}",
-                        last_name="Demo",
-                        role_id=student_role.id,
-                        is_active=True)
-            user.set_password('student123')
+            user = User(
+                email=email,
+                first_name=f"Student{i}",
+                last_name="Demo",
+                role_id=student_role.id,
+                is_active=True,
+                phone="0102030405",
+                address="1 Student Rd",
+                birthdate=date(2010, 1, 1),
+            )
+            user.set_password("student123")
             db.session.add(user)
             db.session.commit()
-            profile = Student(user_id=user.id,
-                               student_number=f"STU{i:03d}",
-                               class_name=random.choice(class_groups),
-                               enrollment_date=date.today())
+            profile = Student(
+                user_id=user.id,
+                student_number=f"STU{i:03d}",
+                class_name=random.choice(class_groups),
+                enrollment_date=date.today(),
+            )
             db.session.add(profile)
             students.append(profile)
         else:
-            students.append(Student.query.join(User).filter(User.email==email).first())
+            students.append(
+                Student.query.join(User).filter(User.email == email).first()
+            )
     db.session.commit()
 
     # Specific student for testing
-    if not User.query.filter_by(email='dossoufares@gmail.com').first():
-        user = User(email='dossoufares@gmail.com',
-                    first_name='Fares',
-                    last_name='Dossou',
-                    role_id=student_role.id,
-                    is_active=True)
-        user.set_password('student123')
+    if not User.query.filter_by(email="dossoufares@gmail.com").first():
+        user = User(
+            email="dossoufares@gmail.com",
+            first_name="Fares",
+            last_name="Dossou",
+            role_id=student_role.id,
+            is_active=True,
+            phone="0102030405",
+            address="1 Student Rd",
+            birthdate=date(2010, 1, 1),
+        )
+        user.set_password("student123")
         db.session.add(user)
         db.session.commit()
-        student_profile = Student(user_id=user.id,
-                                  student_number='STU900',
-                                  class_name='6A',
-                                  enrollment_date=date.today())
+        student_profile = Student(
+            user_id=user.id,
+            student_number="STU900",
+            class_name="6A",
+            enrollment_date=date.today(),
+        )
         db.session.add(student_profile)
         students.append(student_profile)
         db.session.commit()
     else:
-        students.append(Student.query.join(User).filter(User.email=='dossoufares@gmail.com').first())
+        students.append(
+            Student.query.join(User)
+            .filter(User.email == "dossoufares@gmail.com")
+            .first()
+        )
     # Parents
     parents = []
     for i in range(1, 51):
         email = f"parent{i}@mail.fr"
         if not User.query.filter_by(email=email).first():
-            user = User(email=email,
-                        first_name=f"Parent{i}",
-                        last_name="Demo",
-                        role_id=parent_role.id,
-                        is_active=True)
-            user.set_password('parent123')
+            user = User(
+                email=email,
+                first_name=f"Parent{i}",
+                last_name="Demo",
+                role_id=parent_role.id,
+                is_active=True,
+                phone="0102030405",
+                address="1 Parent Ave",
+                birthdate=date(1980, 1, 1),
+            )
+            user.set_password("parent123")
             db.session.add(user)
             db.session.commit()
             profile = Parent(user_id=user.id)
             db.session.add(profile)
             parents.append(profile)
         else:
-            parents.append(Parent.query.join(User).filter(User.email==email).first())
+            parents.append(Parent.query.join(User).filter(User.email == email).first())
     db.session.commit()
 
     # Specific parent for testing
-    if not User.query.filter_by(email='mlalarochelle17x@gmail.com').first():
-        user = User(email='mlalarochelle17x@gmail.com',
-                    first_name='Test',
-                    last_name='Parent',
-                    role_id=parent_role.id,
-                    is_active=True)
-        user.set_password('parent123')
+    if not User.query.filter_by(email="mlalarochelle17x@gmail.com").first():
+        user = User(
+            email="mlalarochelle17x@gmail.com",
+            first_name="Test",
+            last_name="Parent",
+            role_id=parent_role.id,
+            is_active=True,
+            phone="0102030405",
+            address="1 Parent Ave",
+            birthdate=date(1980, 1, 1),
+        )
+        user.set_password("parent123")
         db.session.add(user)
         db.session.commit()
         parent_profile = Parent(user_id=user.id)
         db.session.add(parent_profile)
         parents.append(parent_profile)
         db.session.commit()
-        if students and not ParentStudent.query.filter_by(parent_id=parent_profile.id, student_id=students[0].id).first():
-            link = ParentStudent(parent_id=parent_profile.id, student_id=students[0].id, relationship_type="parent")
+        if (
+            students
+            and not ParentStudent.query.filter_by(
+                parent_id=parent_profile.id, student_id=students[0].id
+            ).first()
+        ):
+            link = ParentStudent(
+                parent_id=parent_profile.id,
+                student_id=students[0].id,
+                relationship_type="parent",
+            )
             db.session.add(link)
             db.session.commit()
     else:
-        parent_profile = Parent.query.join(User).filter(User.email=='mlalarochelle17x@gmail.com').first()
+        parent_profile = (
+            Parent.query.join(User)
+            .filter(User.email == "mlalarochelle17x@gmail.com")
+            .first()
+        )
         parents.append(parent_profile)
     # Link parents to students (2 students per parent when possible)
     for idx, parent in enumerate(parents):
-        child_indices = [idx*2, idx*2+1]
+        child_indices = [idx * 2, idx * 2 + 1]
         for ci in child_indices:
             if ci < len(students):
-                if not ParentStudent.query.filter_by(parent_id=parent.id, student_id=students[ci].id).first():
-                    link = ParentStudent(parent_id=parent.id, student_id=students[ci].id, relationship_type='parent')
+                if not ParentStudent.query.filter_by(
+                    parent_id=parent.id, student_id=students[ci].id
+                ).first():
+                    link = ParentStudent(
+                        parent_id=parent.id,
+                        student_id=students[ci].id,
+                        relationship_type="parent",
+                    )
                     db.session.add(link)
     db.session.commit()
 
@@ -204,14 +309,20 @@ def create_sample_data():
         "Technology",
         "Physical Education",
         "Art",
-        "Music"
+        "Music",
     ]
     courses = []
     for idx, name in enumerate(course_names, start=1):
         code = f"COUR{idx:03d}"
         if not Course.query.filter_by(code=code).first():
-            teacher = teachers[(idx-1) % len(teachers)]
-            course = Course(name=name, code=code, description=f"Course on {name}", credits=1, teacher_id=teacher.id)
+            teacher = teachers[(idx - 1) % len(teachers)]
+            course = Course(
+                name=name,
+                code=code,
+                description=f"Course on {name}",
+                credits=1,
+                teacher_id=teacher.id,
+            )
             db.session.add(course)
             courses.append(course)
         else:
@@ -220,43 +331,53 @@ def create_sample_data():
 
     # Schedules (one random slot per course and class)
     days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-    time_slots = [(time(8,0), time(9,0)), (time(9,0), time(10,0)), (time(10,0), time(11,0)), (time(11,0), time(12,0))]
+    time_slots = [
+        (time(8, 0), time(9, 0)),
+        (time(9, 0), time(10, 0)),
+        (time(10, 0), time(11, 0)),
+        (time(11, 0), time(12, 0)),
+    ]
     for course in courses:
         for group in class_groups:
             start, end = random.choice(time_slots)
-            sched = Schedule(course_id=course.id,
-                             day_of_week=random.choice(days),
-                             start_time=start,
-                             end_time=end,
-                             classroom=f"{random.randint(1,20)}A",
-                             class_group=group)
+            sched = Schedule(
+                course_id=course.id,
+                day_of_week=random.choice(days),
+                start_time=start,
+                end_time=end,
+                classroom=f"{random.randint(1,20)}A",
+                class_group=group,
+            )
             db.session.add(sched)
     db.session.commit()
 
     # Grades (one grade per student per course)
     for student in students:
         for course in courses:
-            grade = Grade(student_id=student.id,
-                          course_id=course.id,
-                          grade_value=round(random.uniform(5, 20), 2),
-                          grade_type="Test",
-                          date_recorded=datetime.utcnow(),
-                          teacher_id=course.teacher_id,
-                          comments="")
+            grade = Grade(
+                student_id=student.id,
+                course_id=course.id,
+                grade_value=round(random.uniform(5, 20), 2),
+                grade_type="Test",
+                date_recorded=datetime.utcnow(),
+                teacher_id=course.teacher_id,
+                comments="",
+            )
             db.session.add(grade)
     db.session.commit()
 
     # Absences (0-2 random absences per student)
     for student in students:
         for _ in range(random.randint(0, 2)):
-            absence = Absence(student_id=student.id,
-                              date=date.today() - timedelta(days=random.randint(1, 30)),
-                              period='Day',
-                              is_justified=random.choice([True, False]),
-                              reason='Illness',
-                              teacher_id=random.choice(teachers).id)
+            absence = Absence(
+                student_id=student.id,
+                date=date.today() - timedelta(days=random.randint(1, 30)),
+                period="Day",
+                is_justified=random.choice([True, False]),
+                reason="Illness",
+                teacher_id=random.choice(teachers).id,
+            )
             db.session.add(absence)
     db.session.commit()
 
     print("Sample data created")
-


### PR DESCRIPTION
## Summary
- expand `User` model with `address` and `birthdate`
- include optional address and birthdate inputs in forms
- extend sample data generation with the new user fields
- add role-specific data to the profile route
- redesign `profile.html` to show details for all roles

## Testing
- `black models.py forms.py routes/main.py utils/admin.py`
- `SECRET_KEY=testsecret PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895e7710b88329b3180442450716a4