### PR TITLE
Fix missing templates for admin and student routes

### DIFF
--- a/templates/admin/add_course.html
+++ b/templates/admin/add_course.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{# Template created so the admin can add courses #}
+{% block title %}Add Course{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-journal-plus me-2"></i>Add Course</h2>
+<form method="POST" class="needs-validation" novalidate>
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.name.label(class="form-label") }}{{ form.name(class="form-control") }}</div>
+    <div class="mb-3">{{ form.code.label(class="form-label") }}{{ form.code(class="form-control") }}</div>
+    <div class="mb-3">{{ form.description.label(class="form-label") }}{{ form.description(class="form-control") }}</div>
+    <div class="mb-3">{{ form.credits.label(class="form-label") }}{{ form.credits(class="form-control") }}</div>
+    <div class="mb-3">{{ form.teacher_id.label(class="form-label") }}{{ form.teacher_id(class="form-select") }}</div>
+    <div class="d-grid">{{ form.submit(class="btn btn-success") }}</div>
+</form>
+{% endblock %}

--- a/templates/admin/add_user.html
+++ b/templates/admin/add_user.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{# Form template added to allow creating users from admin dashboard #}
+{% block title %}Add User{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-person-plus me-2"></i>Add User</h2>
+<form method="POST" class="needs-validation" novalidate>
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.email.label(class="form-label") }}{{ form.email(class="form-control") }}</div>
+    <div class="mb-3">{{ form.first_name.label(class="form-label") }}{{ form.first_name(class="form-control") }}</div>
+    <div class="mb-3">{{ form.last_name.label(class="form-label") }}{{ form.last_name(class="form-control") }}</div>
+    <div class="mb-3">{{ form.phone.label(class="form-label") }}{{ form.phone(class="form-control") }}</div>
+    <div class="mb-3">{{ form.password.label(class="form-label") }}{{ form.password(class="form-control") }}</div>
+    <div class="mb-3">{{ form.role_id.label(class="form-label") }}{{ form.role_id(class="form-select") }}</div>
+    <div class="mb-3 form-check">{{ form.is_active(class="form-check-input") }}{{ form.is_active.label(class="form-check-label") }}</div>
+    <div class="d-grid">{{ form.submit(class="btn btn-primary") }}</div>
+</form>
+{% endblock %}

--- a/templates/admin/courses.html
+++ b/templates/admin/courses.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{# Listing template added for course management from admin menu #}
+{% block title %}Manage Courses{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-book me-2"></i>Manage Courses</h2>
+<a href="{{ url_for('admin.add_course') }}" class="btn btn-success mb-3">Add Course</a>
+{% if courses %}
+<ul class="list-group">
+    {% for course in courses %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+        {{ course.name }} - {{ course.code }}
+        <span class="small text-muted">{{ course.teacher.user.first_name }} {{ course.teacher.user.last_name }}</span>
+    </li>
+    {% endfor %}
+</ul>
+{% else %}
+<p class="text-muted">No courses defined.</p>
+{% endif %}
+{% endblock %}

--- a/templates/admin/edit_user.html
+++ b/templates/admin/edit_user.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{# Form template added so editing users doesn't fail due to missing page #}
+{% block title %}Edit User{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-pencil-square me-2"></i>Edit User</h2>
+<form method="POST" class="needs-validation" novalidate>
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.email.label(class="form-label") }}{{ form.email(class="form-control") }}</div>
+    <div class="mb-3">{{ form.first_name.label(class="form-label") }}{{ form.first_name(class="form-control") }}</div>
+    <div class="mb-3">{{ form.last_name.label(class="form-label") }}{{ form.last_name(class="form-control") }}</div>
+    <div class="mb-3">{{ form.phone.label(class="form-label") }}{{ form.phone(class="form-control") }}</div>
+    <div class="mb-3">{{ form.password.label(class="form-label") }}{{ form.password(class="form-control") }}</div>
+    <div class="mb-3">{{ form.role_id.label(class="form-label") }}{{ form.role_id(class="form-select") }}</div>
+    <div class="mb-3 form-check">{{ form.is_active(class="form-check-input") }}{{ form.is_active.label(class="form-check-label") }}</div>
+    <div class="d-grid">{{ form.submit(class="btn btn-primary") }}</div>
+</form>
+{% endblock %}

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{# Added to provide user management page referenced by navigation and admin routes #}
+{% block title %}Manage Users{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-people me-2"></i>Manage Users</h2>
+<a href="{{ url_for('admin.add_user') }}" class="btn btn-primary mb-3">Add User</a>
+{% if users.items %}
+<div class="table-responsive">
+    <table class="table table-sm" id="usersTable">
+        <thead><tr><th>Email</th><th>Name</th><th>Role</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+        {% for user in users.items %}
+        <tr>
+            <td>{{ user.email }}</td>
+            <td>{{ user.first_name }} {{ user.last_name }}</td>
+            <td>{{ user.role.name }}</td>
+            <td>{{ 'Active' if user.is_active else 'Disabled' }}</td>
+            <td>
+                <a href="{{ url_for('admin.edit_user', user_id=user.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form action="{{ url_for('admin.delete_user', user_id=user.id) }}" method="post" class="d-inline">
+                    <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm-delete>Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted">No users found.</p>
+{% endif %}
+{% endblock %}

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{# Fallback dashboard for undefined roles #}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<div class="text-center py-5">
+    <h2>Welcome to the dashboard</h2>
+    <p class="text-muted">Your role does not have a dedicated dashboard.</p>
+</div>
+{% endblock %}

--- a/templates/student/absences.html
+++ b/templates/student/absences.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{# Template created so students can see their absences #}
+{% block title %}My Absences{% endblock %}
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-calendar-x me-2"></i>My Absences</h2>
+{% if absences %}
+<div class="table-responsive">
+    <table class="table table-sm">
+        <thead><tr><th>Date</th><th>Period</th><th>Justified</th></tr></thead>
+        <tbody>
+        {% for absence in absences %}
+        <tr>
+            <td>{{ absence.date.strftime('%d/%m/%Y') }}</td>
+            <td>{{ absence.period }}</td>
+            <td>{{ 'Yes' if absence.is_justified else 'No' }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted text-center">No absences recorded.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add missing admin templates for managing users and courses
- create fallback dashboard for unknown roles
- provide student absence page
- ensure navigation links work correctly

## Testing
- `pip install -q -r requirements.txt`
- `SECRET_KEY=testkey PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896bdef628832995e357e9ea49433d