### PR TITLE
Improve schedule UI docs

### DIFF
--- a/docs/SCHEDULE_UI_GUIDE.md
+++ b/docs/SCHEDULE_UI_GUIDE.md
@@ -1,0 +1,59 @@
+# Emploi du temps - Design Guide
+
+Ce document décrit les principes d'interface pour la nouvelle page d'emploi du temps, valide pour les rôles Étudiant, Parent, Professeur et Administrateur.
+
+## 1. Vue Calendrier Responsive
+- Basée sur **FullCalendar** avec habillage Tailwind / Bootstrap.
+- Code couleur par matière ou type de session (cours, TP, réunion).
+- Ligne "maintenant" visible pour situer l'heure actuelle.
+
+## 2. Options de Vue
+- Semaine (par défaut), Jour, Mois accessibles depuis la barre du calendrier.
+- Filtres :
+  - **Admin** : par classe ou enseignant.
+  - **Professeur** : par groupe ou classe.
+  - **Parent** : sélection d'un enfant.
+  - **Étudiant** : uniquement son propre emploi du temps.
+
+## 3. Micro‑interactions
+- Tooltip au survol affichant salle, enseignant et description.
+- Glisser‑déposer ou clic pour créer/modifier un créneau (admin et prof).
+- Bouton "Exporter" pour iCal/CSV et version imprimable épurée.
+
+## 4. Accessibilité
+- Contrastes respectant les recommandations WCAG AA.
+- Navigation clavier complète (tabulation sur les événements, raccourcis pour changer de vue).
+- Labels ARIA sur les boutons et la zone calendrier.
+
+## 5. Maquettes ASCII
+
+### Étudiant / Parent – Vue Semaine (Desktop)
+```
++-----------------------------------------------------------+
+| < Septembre 2024 >  [Jour] [Semaine] [Mois]               |
++------+-----+-----+-----+-----+-----+-----+
+| Heure| Lun | Mar | Mer | Jeu | Ven | Sam |
++------+-----+-----+-----+-----+-----+-----+
+| 8h   |Maths|     |Phys.|     |     |     |
+| 9h   | ...                                     |
++------+-----+-----+-----+-----+-----+-----+
+```
+
+### Professeur / Admin – Vue Jour (Mobile)
+```
++-------------------------------+
+| Aujourd'hui      [Filtres]    |
++-------------------------------+
+|08h30  [Cours Maths 1ère A]    |
+|10h30  [TP Physique]           |
+|...                            |
++-------------------------------+
+```
+
+## 6. Composants Principaux
+- **CalendarHeader** : boutons de navigation et sélecteurs.
+- **EventItem** : affiche matière, salle et info rapide.
+- **FilterPanel** : liste déroulante selon le rôle connecté.
+
+## 7. Exemple de composant React
+Un exemple complet est disponible dans [`docs/snippets/schedule_component.jsx`](snippets/schedule_component.jsx).

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -19,4 +19,11 @@
 - **Buttons**: `.btn` with 8px radius, primary colors.
 - **Progress Bars**: Use Bootstrap `.progress` with contextual classes.
 - **Badges**: `.badge` for status indicators.
+- **Calendar**: based on FullCalendar, responsive with Tailwind classes.
+
+## Schedule Colors
+- **Cours** : `#0d6efd`
+- **TP** : `#198754`
+- **Réunion** : `#6f42c1`
+- **Examen** : `#dc3545`
 

--- a/docs/snippets/schedule_component.jsx
+++ b/docs/snippets/schedule_component.jsx
@@ -1,0 +1,38 @@
+import React, { useRef, useEffect } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+// Tailwind CSS classes are used for spacing and layout.
+import './schedule.css';
+
+export default function Schedule({ events, onEventAdd, onEventChange }) {
+  const calendarRef = useRef(null);
+
+  useEffect(() => {
+    let calendarApi = calendarRef.current.getApi();
+    calendarApi.render();
+  }, []);
+
+  return (
+    <div className="schedule-container p-4 bg-white rounded shadow">
+      <FullCalendar
+        ref={calendarRef}
+        plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
+        headerToolbar={{
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,timeGridWeek,timeGridDay'
+        }}
+        events={events}
+        nowIndicator={true}
+        editable={true}
+        selectable={true}
+        eventAdd={onEventAdd}
+        eventChange={onEventChange}
+        height="auto"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- document responsive schedule UI guidelines
- provide React example using FullCalendar and Tailwind
- extend styleguide with calendar notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6889789354148329b1f357eaca28b498