### PR TITLE
Fix schedule page initialization

### DIFF
--- a/static/js/schedule.js
+++ b/static/js/schedule.js
@@ -1,7 +1,7 @@
 // Schedule calendar initialization using FullCalendar
 // Requires a div with id 'scheduleCalendar' and a data-events attribute
 
-document.addEventListener('DOMContentLoaded', function() {
+function initScheduleCalendar() {
   var calendarEl = document.getElementById('scheduleCalendar');
   if (!calendarEl) return;
 
@@ -27,4 +27,10 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   calendar.render();
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initScheduleCalendar);
+} else {
+  initScheduleCalendar();
+}


### PR DESCRIPTION
## Summary
- ensure schedule calendar renders even when DOMContentLoaded already fired

## Testing
- `SECRET_KEY=test PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897aea2214832997e290a11c9eb723