### PR TITLE
Update README environment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,7 @@ FLUSH PRIVILEGES;
 
 ### 5. Configuration des variables d'environnement
 
-Copier le fichier exemple :
-```bash
-cp .env.example .env
-```
-
-Modifier le fichier `.env` avec vos paramètres :
+Créez un fichier `.env` à la racine du projet et renseignez les variables suivantes :
 ```bash
 # Configuration de l'application
 SECRET_KEY=votre-clé-secrète-très-sécurisée
@@ -123,10 +118,8 @@ même port.
 
 ### 1. Avec Docker Compose (recommandé)
 ```bash
-# Copier le fichier docker-compose et ajuster les variables
-cp docker-compose.yml.example docker-compose.yml
+# Démarrer les services (ajustez les variables dans `docker-compose.yml` si besoin)
 
-# Démarrer les services
 docker-compose up -d
 
 # Initialiser les données d'exemple


### PR DESCRIPTION
## Summary
- fix README to explain how to create the `.env` file
- fix Docker section instructions

## Testing
- `pip install -r requirements.txt`
- `SECRET_KEY=test PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688997e964b883298c9074fae03861e2