### PR TITLE
Fix teacher dashboard counts and add absences view

### DIFF
--- a/routes/teacher.py
+++ b/routes/teacher.py
@@ -136,3 +136,14 @@ def grades():
     return render_template('teacher/grades.html', grades=grades,
                            average=average, best=best,
                            high_count=high_count, low_count=low_count)
+
+
+@bp.route('/absences')
+@login_required
+@teacher_required
+def absences():
+    teacher = current_user.teacher_profile
+    absences = Absence.query.filter_by(teacher_id=teacher.id)\
+                            .join(Student)\
+                            .order_by(Absence.date.desc()).all()
+    return render_template('teacher/absences.html', absences=absences)

--- a/templates/teacher/absences.html
+++ b/templates/teacher/absences.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}Recorded Absences{% endblock %}
+
+{% block content %}
+<h2 class="mb-4"><i class="bi bi-calendar-x me-2"></i>Recorded Absences</h2>
+{% if absences %}
+<div class="table-responsive">
+    <table class="table table-sm align-middle">
+        <thead>
+            <tr>
+                <th>Student</th>
+                <th>Date</th>
+                <th>Period</th>
+                <th>Justified</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for absence in absences %}
+            <tr>
+                <td>{{ absence.student.user.first_name }} {{ absence.student.user.last_name }}</td>
+                <td>{{ absence.date.strftime('%d/%m/%Y') }}</td>
+                <td>{{ absence.period }}</td>
+                <td>{{ 'Yes' if absence.is_justified else 'No' }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="text-muted text-center">No absences recorded.</p>
+{% endif %}
+{% endblock %}

--- a/templates/teacher/dashboard.html
+++ b/templates/teacher/dashboard.html
@@ -14,31 +14,37 @@
 
 <div class="row mb-4">
     <div class="col-md-4 mb-3">
-        <div class="card bg-primary text-white text-center">
-            <div class="card-body">
-                <i class="bi bi-people fs-1"></i>
-                <h4>{{ total_students }}</h4>
-                <p class="mb-0">Students</p>
+        <a href="{{ url_for('teacher.courses') }}" class="text-decoration-none text-white">
+            <div class="card bg-primary text-white text-center">
+                <div class="card-body">
+                    <i class="bi bi-people fs-1"></i>
+                    <h4>{{ total_students }}</h4>
+                    <p class="mb-0">Students</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col-md-4 mb-3">
-        <div class="card bg-success text-white text-center">
-            <div class="card-body">
-                <i class="bi bi-clipboard-data fs-1"></i>
-                <h4>{{ total_grades }}</h4>
-                <p class="mb-0">Grades entered</p>
+        <a href="{{ url_for('teacher.grades') }}" class="text-decoration-none text-white">
+            <div class="card bg-success text-white text-center">
+                <div class="card-body">
+                    <i class="bi bi-clipboard-data fs-1"></i>
+                    <h4>{{ total_grades }}</h4>
+                    <p class="mb-0">Grades entered</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col-md-4 mb-3">
-        <div class="card bg-warning text-white text-center">
-            <div class="card-body">
-                <i class="bi bi-calendar-x fs-1"></i>
-                <h4>{{ total_absences }}</h4>
-                <p class="mb-0">Absences</p>
+        <a href="{{ url_for('teacher.absences') }}" class="text-decoration-none text-white">
+            <div class="card bg-warning text-white text-center">
+                <div class="card-body">
+                    <i class="bi bi-calendar-x fs-1"></i>
+                    <h4>{{ total_absences }}</h4>
+                    <p class="mb-0">Absences</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
 </div>
 

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -347,6 +347,20 @@ def create_sample_data():
             courses.append(Course.query.filter_by(code=code).first())
     db.session.commit()
 
+    # Ensure Thomas LECERIER has a course
+    thomas = Teacher.query.join(User).filter(User.email == "gbtexfares@gmail.com").first()
+    if thomas and not Course.query.filter_by(teacher_id=thomas.id).first():
+        special = Course(
+            name="Advanced Mathematics",
+            code="COUR900",
+            description="Course on Advanced Mathematics",
+            credits=1,
+            teacher_id=thomas.id,
+        )
+        db.session.add(special)
+        db.session.commit()
+        courses.append(special)
+
     # Schedules (one random slot per course and class)
     days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
     time_slots = [


### PR DESCRIPTION
## Summary
- make teacher dashboard stats clickable
- add a page to list absences recorded by a teacher
- link stats cards to their respective pages
- ensure sample data assigns a course to Thomas Lecerier

## Testing
- `SECRET_KEY=test PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c98c186c83298ce05acf15abcd60