### PR TITLE
Hide prod credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ pytest tests/test_auth.py
 pytest tests/test_models.py
 ```
 
-## 📊 Comptes de Test
+## 📊 Comptes de Test *(développement uniquement)*
 
-Après l'initialisation des données d'exemple :
+Les identifiants ci-dessous sont fournis **uniquement pour le développement et les tests** après l'initialisation des données d'exemple :
 
 | Rôle | Email | Mot de passe |
 |------|--------|-------------|

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -64,6 +64,7 @@
             <strong>MFA security:</strong> After entering your credentials, a verification code will be sent to your email address.
         </div>
         
+        {% if config.DEBUG %}
         <!-- Test accounts -->
         <div class="card mt-3">
             <div class="card-header bg-light">
@@ -103,6 +104,7 @@
                 </div>
             </div>
         </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display login test accounts only when `DEBUG` is enabled
- mark README credential table as development-only

## Testing
- `pip install -r requirements.txt`
- `SECRET_KEY=test PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889cec8e40c8329baa1db41589bea78