### PR TITLE
Add password reset link on login page

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -55,6 +55,9 @@
                         Don't have an account?
                         <a href="{{ url_for('auth.register') }}" class="text-decoration-none">Sign up</a>
                     </p>
+                    <a href="{{ url_for('auth.reset_request') }}" class="text-decoration-none">
+                        <i class="bi bi-key me-1"></i>Forgot your password?
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a link to request password reset on the login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889d8e557b48329acbcb7a05c1d4ab7